### PR TITLE
Initial matinee support to control facial animations on actors

### DIFF
--- a/Source/FaceFX/Classes/Animation/FaceFXComponent.h
+++ b/Source/FaceFX/Classes/Animation/FaceFXComponent.h
@@ -122,6 +122,12 @@ public:
 	bool Stop(USkeletalMeshComponent* SkelMeshComp = nullptr, const UObject* Caller = nullptr);
 
 	/**
+	* Stops the playback of all currently playing facial animations for any skel mesh components character
+	*/
+	UFUNCTION(BlueprintCallable, Category=FaceFX)
+	void StopAll();
+
+	/**
 	* Pause the playback of the currently playing facial animation for a given skel mesh components character
 	* @param SkelMeshComp The skelmesh component to pause the playback for. Keep nullptr to use the first setup skelmesh component character instead
 	* @returns True if succeeded, else false

--- a/Source/FaceFX/Classes/FaceFXActor.h
+++ b/Source/FaceFX/Classes/FaceFXActor.h
@@ -160,6 +160,12 @@ public:
 	*/
 	void GetAnimationGroups(TArray<FName>& OutGroups) const;
 
+	/**
+	* Gets all animation ids
+	* @param OutAnimIds The animation ids
+	*/
+	void GetAnimationIds(TArray<FFaceFXAnimId>& OutAnimIds) const;
+
 #endif //FACEFX_USEANIMATIONLINKAGE
 
 #if WITH_EDITORONLY_DATA

--- a/Source/FaceFX/Classes/FaceFXCharacter.h
+++ b/Source/FaceFX/Classes/FaceFXCharacter.h
@@ -543,5 +543,20 @@ private:
 
 #if WITH_EDITOR
 	uint32 LastFrameNumber;
+
+	/** The event callback handle for OnFaceFXAnimChanged */
+	FDelegateHandle OnFaceFXAnimChangedHandle;
+
+	/** 
+	* Callback for when an asset changed
+	* @param Asset The asset which changed
+	*/
+	void OnFaceFXAssetChanged(class UFaceFXAsset* Asset);
+
+	DECLARE_MULTICAST_DELEGATE_OneParam(FOnAssetChangedSignature, class UFaceFXAsset* /*Asset*/);
+
+public:
+	/** Event that gets triggered when an animation asset gets loaded */
+	static FOnAssetChangedSignature OnAssetChanged;
 #endif //WITH_EDITOR
 };

--- a/Source/FaceFX/Classes/FaceFXCharacter.h
+++ b/Source/FaceFX/Classes/FaceFXCharacter.h
@@ -107,7 +107,17 @@ public:
 	* Restarts the current animation
 	* @returns True if succeeded, else false
 	*/
-	bool Restart();
+	inline bool Restart()
+	{
+		return JumpTo(0.F);
+	}
+
+	/** 
+	* Jumps to a given position within the facial animation playback
+	* @param Position The target position to jump to (in seconds). Ranges from 0 to animation duration
+	* @returns True if succeeded, else false
+	*/
+	bool JumpTo(float Position);
 
 	/** Reset the whole character setup */
 	void Reset();
@@ -134,8 +144,35 @@ public:
 	*/
 	inline bool IsPlaying() const
 	{
-		return bIsPlaying;
+		return AnimPlaybackState == EPlaybackState::Playing;
 	}
+
+	/**
+	* Gets the indicator if the character is playing a facial animation right now or if one is paused
+	* @returns True if playing, else false
+	*/
+	inline bool IsPlayingOrPaused() const
+	{
+		return AnimPlaybackState != EPlaybackState::Stopped;
+	}
+
+	/**
+	* Gets the indicator if the character is currently playing an animation with the given animation id
+	* @param AnimId The id to look for
+	* @returns True if such an animation is currently playing, else false
+	*/
+	inline bool IsPlayingOrPaused(const FFaceFXAnimId& AnimId) const
+	{
+		//look for the animation by id. If no group is set for the given AnimId, ignore group during comparison
+		return IsPlayingOrPaused() && ((!AnimId.Group.IsNone() && CurrentAnim == AnimId) || AnimId.Name == CurrentAnim.Name);
+	}
+
+	/**
+	* Gets the indicator if the character is currently playing a given animation
+	* @param Animation The animation to look for
+	* @returns True if such an animation is currently playing, else false
+	*/
+	bool IsPlayingOrPaused(const class UFaceFXAnim* Animation) const;
 
 	/** 
 	* Gets the indicator if this character is currently pausing a facial animation
@@ -143,7 +180,7 @@ public:
 	*/
 	inline bool IsPaused() const
 	{
-		return !bIsPlaying && CurrentAnimHandle;
+		return AnimPlaybackState == EPlaybackState::Paused && CurrentAnimHandle;
 	}
 
 	/**
@@ -152,7 +189,7 @@ public:
 	*/
 	inline bool IsPlayingAudio() const
 	{
-		return bIsPlayingAudio;
+		return AudioPlaybackState == EPlaybackState::Playing;
 	}
 
 	/**
@@ -229,16 +266,71 @@ public:
 		return FaceFXActor;
 	}
 
+	/** 
+	* Sets the audio component for this character
+	* @param Component The new audio component
+	*/
+	inline void SetAudioComponent(class UAudioComponent* Component)
+	{
+		AudioComponent = Component;
+	}
+
 	//FTickableGameObject
 	virtual void Tick(float DeltaTime) override;
 	virtual bool IsTickable() const override;
 	virtual TStatId GetStatId() const override;
 	//~FTickableGameObject
 
+#if FACEFX_USEANIMATIONLINKAGE
+
+	/** 
+	* Gets the start and end time of a given animation
+	* @param Actor Contextual actor to fetch the FaceFX character from
+	* @param AnimId The animation id to fetch the bounds for
+	* @param OutStart The start time if call succeeded
+	* @param OutEnd The end time if call succeeded
+	* @returns True if succeeded, else false
+	*/
+	static bool GetAnimationBoundsById(const AActor* Actor, const FFaceFXAnimId& AnimId, float& OutStart, float& OutEnd);
+
+	/** 
+	* Gets the start and end time of a given animation
+	* @param AnimId The animation id to fetch the bounds for
+	* @param OutStart The start time if call succeeded
+	* @param OutEnd The end time if call succeeded
+	* @returns True if succeeded, else false
+	*/
+	bool GetAnimationBoundsById(const FFaceFXAnimId& AnimId, float& OutStart, float& OutEnd) const;
+
+	/** 
+	* Gets the list of animation ids of all animations that are currently linked to this character
+	* @param OutAnimIds The resulting list of animation ids
+	* @returns True if call succeeded, else false
+	*/
+	bool GetAllLinkedAnimationIds(TArray<FFaceFXAnimId>& OutAnimIds) const;
+#endif //FACEFX_USEANIMATIONLINKAGE
+
+	/** 
+	* Gets the start and end time of a given animation
+	* @param Animation The animation to fetch the bounds for
+	* @param OutStart The start time if call succeeded
+	* @param OutEnd The end time if call succeeded
+	* @returns True if succeeded, else false
+	*/
+	static bool GetAnimationBounds(const class UFaceFXAnim* Animation, float& OutStart, float& OutEnd);
+	
 	/** Event that triggers whenever an asset was tried to get played which is incompatible to the FaceFX actor handle */
 	static FOnFaceFXCharacterPlayAssetIncompatibleSignature OnFaceFXCharacterPlayAssetIncompatible;
 
 private:
+
+	/** The different playback states */
+	enum class EPlaybackState
+	{
+		Playing,
+		Paused,
+		Stopped
+	};
 
 	/**
 	* Gets the currently playing animation
@@ -253,10 +345,10 @@ private:
 	* Gets the owning actor
 	* @returns The actor or nullptr if not belonging to one
 	*/
-	class AActor* GetOwnningActor() const;
+	class AActor* GetOwningActor() const;
 
 	/** 
-	* Gets the audio component from the owning actor
+	* Gets the audio component assigned to this character. If not set the audio component will be looked up from the owning actors component list
 	* @returns The audio component or nullptr if not found
 	*/
 	class UAudioComponent* GetAudioComponent() const;
@@ -267,6 +359,12 @@ private:
 	* @returns True if it can play the animation, else false
 	*/
 	bool IsCanPlay(struct ffx_anim_handle_t* AnimationHandle) const;
+
+	/** 
+	* Gets the indicator if the audio start event was triggered within the current frame state
+	* @returns True if audio was started, else false
+	*/
+	bool IsAudioStarted();
 
 	/** 
 	* Gets the start and end time of the current animation
@@ -302,7 +400,18 @@ private:
 	* @param OutAudioComp The audio component on which audio was started to play. Unchanged if function returns false
 	* @returns True if audio playback successfully started on the owning actors Audio component, else false
 	*/
-	bool PlayAudio(class UAudioComponent** OutAudioComp = nullptr);
+	inline bool PlayAudio(class UAudioComponent** OutAudioComp = nullptr)
+	{
+		return PlayAudio(0.F, OutAudioComp);
+	}
+
+	/** 
+	* Plays the audio if available 
+	* @param Position The position to start the audio at. Ranging from 0 to audio playback duration. Keep at 0 to start from the beginning. Will be clamped at 0
+	* @param OutAudioComp The audio component on which audio was started to play. Unchanged if function returns false
+	* @returns True if audio playback successfully started on the owning actors Audio component, else false
+	*/
+	bool PlayAudio(float Position = 0.F, class UAudioComponent** OutAudioComp = nullptr);
 
 	/** 
 	* Pausing the playback of the currently playing audio
@@ -322,6 +431,24 @@ private:
 	*/
 	bool ResumeAudio();
 
+	/** Enforces a tick with a zero delta */
+	inline void EnforceZeroTick()
+	{
+#if WITH_EDITOR
+		LastFrameNumber = GFrameNumber+1;
+#endif //WITH_EDITOR
+		Tick(0.F);
+	}
+
+	/** 
+	* Performs ticks from 0 to Duration in small enough timesteps to find out the location where the audio was triggered
+	* @param Duration The duration until to tick to
+	* @param OutAudioStarted True if the audio was started until the duration was reached, else false
+	* @param OutAudioStart The start location of audio if true was returned
+	* @returns True if succeeded with ticking until the duration, else false
+	*/
+	bool TickUntil(float Duration, bool& OutAudioStarted, float& OutAudioStart);
+
 	/**
 	* Gets the latest internal facefx error message
 	* @returns The last error message
@@ -338,6 +465,10 @@ private:
 	/** The data set from where this character was loaded from */
 	UPROPERTY()
 	const UFaceFXActor* FaceFXActor;
+
+	/** The audio component assigned to this character */
+	UPROPERTY()
+	class UAudioComponent* AudioComponent;
 
 	/** The associated actor handle */
 	struct ffx_actor_handle_t* ActorHandle;
@@ -372,6 +503,9 @@ private:
 	/** The total duration of the currently playing animation */
 	float CurrentAnimDuration;
 
+	/** The starting location of the currently playing animation */
+	float CurrentAnimStart;
+
 	/** The location at which we are right now on the audio playback (in seconds) */
 	float CurrentAudioProgress;
 
@@ -381,14 +515,14 @@ private:
 	/** The current audio asset that was assigned to the current animation*/
 	TAssetPtr<class USoundWave> CurrentAnimSound;
 
+	/** The animation playback state */
+	EPlaybackState AnimPlaybackState;
+
+	/** The audio playback state */
+	EPlaybackState AudioPlaybackState;
+
 	/** Dirty indicator */
 	uint8 bIsDirty : 1;
-
-	/** Playing indicator */
-	uint8 bIsPlaying : 1;
-
-	/** Audio Playing indicator */
-	uint8 bIsPlayingAudio : 1;
 
 	/** Looping indicator for the currently playing animation */
 	uint8 bIsLooping : 1;

--- a/Source/FaceFX/Classes/FaceFXCharacter.h
+++ b/Source/FaceFX/Classes/FaceFXCharacter.h
@@ -192,6 +192,15 @@ public:
 		return AudioPlaybackState == EPlaybackState::Playing;
 	}
 
+	/** 
+	* Gets the indicator if the audio is currently playing or paused
+	* @returns True if paused or playing, else false
+	*/
+	inline bool IsPlayingOrPausedAudio() const
+	{
+		return AudioPlaybackState != EPlaybackState::Stopped;
+	}
+
 	/**
 	* Gets the indicator if the current animation is looping
 	* @returns True if looping else false
@@ -444,10 +453,9 @@ private:
 	* Performs ticks from 0 to Duration in small enough timesteps to find out the location where the audio was triggered
 	* @param Duration The duration until to tick to
 	* @param OutAudioStarted True if the audio was started until the duration was reached, else false
-	* @param OutAudioStart The start location of audio if true was returned
 	* @returns True if succeeded with ticking until the duration, else false
 	*/
-	bool TickUntil(float Duration, bool& OutAudioStarted, float& OutAudioStart);
+	bool TickUntil(float Duration, bool& OutAudioStarted);
 
 	/**
 	* Gets the latest internal facefx error message

--- a/Source/FaceFX/Classes/FaceFXData.h
+++ b/Source/FaceFX/Classes/FaceFXData.h
@@ -284,3 +284,41 @@ struct FFaceFXActorData
 	}
 #endif //WITH_EDITORONLY_DATA
 };
+
+/** A struct that represents a skel mesh component on a FaceFX Component */
+USTRUCT()
+struct FFaceFXSkelMeshComponentId
+{
+	GENERATED_USTRUCT_BODY()
+
+	FFaceFXSkelMeshComponentId() : Index(INDEX_NONE) {}
+
+	/** The index of the setup within a FaceFX component */
+	UPROPERTY()
+	int32 Index;
+
+	/** The expected name of the skel mesh component */
+	UPROPERTY()
+	FName Name;
+
+	/** 
+	* Gets the indicator if this is a valid id
+	* @returns True if valid, else false
+	*/
+	inline bool IsValid() const
+	{
+		return Index != INDEX_NONE && !Name.IsNone();
+	}
+
+	/** Reset the id */
+	inline void Reset()
+	{
+		Index = INDEX_NONE;
+		Name = NAME_None;
+	}
+
+	FORCEINLINE bool operator==(const FFaceFXSkelMeshComponentId& Id) const
+	{
+		return Index == Id.Index && Name == Id.Name;
+	}
+};

--- a/Source/FaceFX/Classes/Matinee/FaceFXMatineeControl.h
+++ b/Source/FaceFX/Classes/Matinee/FaceFXMatineeControl.h
@@ -1,0 +1,139 @@
+/*******************************************************************************
+  The MIT License (MIT)
+  Copyright (c) 2015 OC3 Entertainment, Inc.
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*******************************************************************************/
+
+#pragma once
+
+#include "FaceFXData.h"
+#include "Matinee/InterpTrackFloatBase.h"
+#include "FaceFXMatineeControl.generated.h"
+
+/** Information for one FaceFX key in the track. */
+USTRUCT()
+struct FFaceFXTrackKey
+{
+	GENERATED_USTRUCT_BODY()
+
+	FFaceFXTrackKey() : Time(0.F), bLoop(false), bIsAnimationDurationLoaded(false), AnimationDuration(0.F)	{}
+
+	/** The if of the skel mesh component where this key is working on */
+	UPROPERTY(EditAnywhere, Category=FaceFX)
+	FFaceFXSkelMeshComponentId SkelMeshComponentId;
+
+	/** The animation to play. Only usable when FACEFX_USEANIMATIONLINKAGE is enabled (see FaceFXConfig.h) */
+	UPROPERTY(EditAnywhere, Category=FaceFX)
+	FFaceFXAnimId AnimationId;
+
+	/** The animation to play */
+	UPROPERTY(EditAnywhere, Category=FaceFX)
+	TAssetPtr<UFaceFXAnim> Animation;
+
+	/** The time of the key along the track time line */
+	UPROPERTY()
+	float Time;
+
+	/** Indicator if the facial animation shall loop */
+	UPROPERTY(EditAnywhere, Category=FaceFX)
+	uint8 bLoop : 1;
+
+	/** 
+	* Gets the duration of the assigned animation
+	* @param Actor The contextual actor to fetch the animation id from if needed
+	* @returns The animation duration
+	*/
+	float GetAnimationDuration(const AActor* Actor = nullptr) const;
+
+private:
+
+	/** Indicator if the facial animation duration was loaded already*/
+	UPROPERTY(Transient)
+	mutable uint8 bIsAnimationDurationLoaded : 1;
+
+	/** The duration of the selected animation */
+	UPROPERTY(Transient)
+	mutable float AnimationDuration;
+};
+
+UCLASS(MinimalAPI, meta=( DisplayName = "FaceFX Track" ))
+class UFaceFXMatineeControl : public UInterpTrack
+{
+	GENERATED_UCLASS_BODY()
+
+	friend class UFaceFXMatineeControlHelper;
+
+	//UInterpTrack
+	// Some overrides from UInterpTrack to allow inheriting from another module. Those functions are not exposed my the module via ENGINE_API
+	virtual const FString GetEdHelperClassName() const override
+	{
+		return TEXT("");
+	}
+
+	virtual FColor GetKeyframeColor(int32 KeyIndex) const override
+	{
+		static const FColor KeyNormalColor(0,0,0);
+		return KeyNormalColor;
+	}
+
+#if WITH_EDITORONLY_DATA
+	virtual class UTexture2D* GetTrackIcon() const
+	{
+		return TrackIcon;
+	}
+#endif //WITH_EDITORONLY_DATA
+	//~UInterpTrack
+
+	//UInterpTrack implementations
+	virtual int32 GetNumKeyframes() const override;
+	virtual float GetTrackEndTime() const override;
+	virtual float GetKeyframeTime( int32 KeyIndex ) const override;
+	virtual int32 GetKeyframeIndex( float KeyTime ) const override;
+	virtual void GetTimeRange( float& StartTime, float& EndTime ) const override;
+	virtual int32 SetKeyframeTime( int32 KeyIndex, float NewKeyTime, bool bUpdateOrder = true ) override;
+	virtual void RemoveKeyframe( int32 KeyIndex ) override;
+	virtual int32 DuplicateKeyframe( int32 KeyIndex, float NewKeyTime, UInterpTrack* ToTrack = NULL ) override;
+	virtual bool GetClosestSnapPosition( float InPosition, TArray<int32>& IgnoreKeys, float& OutPosition ) override;
+	virtual int32 AddKeyframe( float Time, UInterpTrackInst* TrackInst, EInterpCurveMode InitInterpMode ) override;
+	virtual void PreviewUpdateTrack( float NewPosition, UInterpTrackInst* TrackInst ) override;
+	virtual void DrawTrack( FCanvas* Canvas, UInterpGroup* Group, const FInterpTrackDrawParams& Params ) override;
+
+#if WITH_EDITORONLY_DATA
+	virtual void UpdateTrack( float NewPosition, UInterpTrackInst* TrackInst, bool bJump ) override;
+#endif // WITH_EDITORONLY_DATA
+
+
+	virtual const FString GetSlateHelperClassName() const override
+	{
+		return FString( TEXT("FaceFXEditor.FaceFXMatineeControlHelper") );
+	}
+	//~UInterpTrack implementations
+
+private:
+
+	/** 
+	* Gets the keyframe data for a given time on the track
+	* @param InTime The time we're currently at on the track
+	* @param OutResult The resulting track keys as a pair of track index and key
+	* @param OutNoTracks The list of skelmesh components that have no tracks (anymore)
+	*/
+	void GetTrackKeyForTime(float InTime, TArray<TPair<int32, const FFaceFXTrackKey*>>& OutResult, TArray<FFaceFXSkelMeshComponentId>* OutNoTracks = nullptr) const;
+
+	/** The keys in this track control */
+	UPROPERTY()
+	TArray<FFaceFXTrackKey> Keys;
+};

--- a/Source/FaceFX/Classes/Matinee/FaceFXMatineeControl.h
+++ b/Source/FaceFX/Classes/Matinee/FaceFXMatineeControl.h
@@ -110,6 +110,7 @@ class UFaceFXMatineeControl : public UInterpTrack
 	virtual bool GetClosestSnapPosition( float InPosition, TArray<int32>& IgnoreKeys, float& OutPosition ) override;
 	virtual int32 AddKeyframe( float Time, UInterpTrackInst* TrackInst, EInterpCurveMode InitInterpMode ) override;
 	virtual void PreviewUpdateTrack( float NewPosition, UInterpTrackInst* TrackInst ) override;
+	virtual void PreviewStopPlayback(class UInterpTrackInst* TrInst) override;
 	virtual void DrawTrack( FCanvas* Canvas, UInterpGroup* Group, const FInterpTrackDrawParams& Params ) override;
 
 #if WITH_EDITORONLY_DATA

--- a/Source/FaceFX/Classes/Matinee/FaceFXMatineeControl.h
+++ b/Source/FaceFX/Classes/Matinee/FaceFXMatineeControl.h
@@ -112,11 +112,7 @@ class UFaceFXMatineeControl : public UInterpTrack
 	virtual void PreviewUpdateTrack( float NewPosition, UInterpTrackInst* TrackInst ) override;
 	virtual void PreviewStopPlayback(class UInterpTrackInst* TrInst) override;
 	virtual void DrawTrack( FCanvas* Canvas, UInterpGroup* Group, const FInterpTrackDrawParams& Params ) override;
-
-#if WITH_EDITORONLY_DATA
 	virtual void UpdateTrack( float NewPosition, UInterpTrackInst* TrackInst, bool bJump ) override;
-#endif // WITH_EDITORONLY_DATA
-
 
 	virtual const FString GetSlateHelperClassName() const override
 	{

--- a/Source/FaceFX/Classes/Matinee/FaceFXMatineeControlInst.h
+++ b/Source/FaceFX/Classes/Matinee/FaceFXMatineeControlInst.h
@@ -1,0 +1,68 @@
+/*******************************************************************************
+  The MIT License (MIT)
+  Copyright (c) 2015 OC3 Entertainment, Inc.
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*******************************************************************************/
+
+#pragma once
+
+#include "Matinee/InterpTrackInst.h"
+#include "FaceFXMatineeControlInst.generated.h"
+
+UCLASS(MinimalAPI)
+class UFaceFXMatineeControlInst : public UInterpTrackInst
+{
+	GENERATED_UCLASS_BODY()
+
+	/** The position at which the last time the update was performed */
+	UPROPERTY(Transient)
+	float LastUpdatePosition;
+	
+	// Begin UInterpTrackInst Instance
+	virtual void InitTrackInst(UInterpTrack* Track) override;
+	// End UInterpTrackInst Instance
+
+	/** 
+	* Gets the current track index for the given skel mesh component
+	* @param SkelMeshComp The skel mesh component to fetch the track index for
+	* @returns The track index or INDEX_NONE if unset
+	*/
+	inline int32 GetCurrentTrackIndex(const class USkeletalMeshComponent* SkelMeshComp) const
+	{
+		if(const int32* Entry = CurrentTrackKeyIndices.Find(SkelMeshComp))
+		{
+			return *Entry;
+		}
+		return INDEX_NONE;
+	}
+
+	/** 
+	* Sets the current track index for the given skel mesh component
+	* @param SkelMeshComp The skel mesh component to set the track index for
+	* @param Index The new index to set
+	*/
+	inline void SetCurrentTrackIndex(const class USkeletalMeshComponent* SkelMeshComp, int32 Index)
+	{
+		CurrentTrackKeyIndices.FindOrAdd(SkelMeshComp) = Index;
+	}
+
+private:
+
+	/** The currently executed track key on a per skelmesh component level*/
+	TMap<const class USkeletalMeshComponent*, int32> CurrentTrackKeyIndices;
+};
+

--- a/Source/FaceFX/Classes/Matinee/FaceFXMatineeControlInst.h
+++ b/Source/FaceFX/Classes/Matinee/FaceFXMatineeControlInst.h
@@ -34,6 +34,7 @@ class UFaceFXMatineeControlInst : public UInterpTrackInst
 	
 	// Begin UInterpTrackInst Instance
 	virtual void InitTrackInst(UInterpTrack* Track) override;
+	virtual void RestoreActorState(UInterpTrack* Track) override;
 	// End UInterpTrackInst Instance
 
 	/** 

--- a/Source/FaceFX/FaceFX.Build.cs
+++ b/Source/FaceFX/FaceFX.Build.cs
@@ -29,10 +29,14 @@ public class FaceFX : ModuleRules
                 "Core",
                 "CoreUObject",
                 "Engine",
-                "TargetPlatform",
                 "FaceFXLib"
             }
         );
+
+        if (UEBuildConfiguration.bBuildEditor)
+        {
+            PrivateDependencyModuleNames.Add("TargetPlatform");
+        }
 
         PublicIncludePathModuleNames.Add("FaceFXLib");
 	}

--- a/Source/FaceFX/Private/Animation/AnimNode_BlendFaceFXAnimation.cpp
+++ b/Source/FaceFX/Private/Animation/AnimNode_BlendFaceFXAnimation.cpp
@@ -113,7 +113,7 @@ void FAnimNode_BlendFaceFXAnimation::LoadFaceFXData(UAnimInstance* AnimInstance)
 			else
 			{
 				//no FaceFX character exist yet -> check if we're currently loading one async
-				bFaceFXCharacterLoadingCompleted = !FaceFXComp->IsLoadingCharacterAsync();
+				bFaceFXCharacterLoadingCompleted = !FaceFXComp->IsLoadingCharacterAsync() && FaceFXComp->IsRegistered();
 			}
 		}
 	}

--- a/Source/FaceFX/Private/Animation/AnimNode_BlendFaceFXAnimation.cpp
+++ b/Source/FaceFX/Private/Animation/AnimNode_BlendFaceFXAnimation.cpp
@@ -63,13 +63,28 @@ void FAnimNode_BlendFaceFXAnimation::LoadFaceFXData(UAnimInstance* AnimInstance)
 	QUICK_SCOPE_CYCLE_COUNTER(STAT_FaceFXBlendLoad);
 
 	BoneIndices.Empty();
-	bFaceFXCharacterLoadingCompleted = true;
 
-	if(USkeletalMeshComponent* Component = AnimInstance ? AnimInstance->GetSkelMeshComponent() : nullptr)
+	if(!AnimInstance)
+	{
+		//wait until we have a proper anim instance
+		bFaceFXCharacterLoadingCompleted = false;
+		return;
+	}
+
+	if(USkeletalMeshComponent* Component = AnimInstance->GetSkelMeshComponent())
 	{
 		AActor* Owner = Component->GetOwner();
 
-		if(UFaceFXComponent* FaceFXComp = Owner ? Owner->FindComponentByClass<UFaceFXComponent>() : nullptr)
+		if(!Owner)
+		{
+			//wait until we have a proper owner
+			bFaceFXCharacterLoadingCompleted = false;
+			return;
+		}
+
+		bFaceFXCharacterLoadingCompleted = true;
+
+		if(UFaceFXComponent* FaceFXComp = Owner->FindComponentByClass<UFaceFXComponent>())
 		{
 			if(UFaceFXCharacter* FaceFXChar = FaceFXComp->GetCharacter(Component))
 			{

--- a/Source/FaceFX/Private/Animation/FaceFXComponent.cpp
+++ b/Source/FaceFX/Private/Animation/FaceFXComponent.cpp
@@ -33,7 +33,7 @@ void UFaceFXComponent::OnRegister()
 	CreateAllCharacters();
 }
 
-bool UFaceFXComponent::Setup(USkeletalMeshComponent* SkelMeshComp, const UFaceFXActor* Asset, bool IsAutoPlaySound, const UObject* Caller)
+bool UFaceFXComponent::Setup(USkeletalMeshComponent* SkelMeshComp, UAudioComponent* AudioComponent, const UFaceFXActor* Asset, bool IsAutoPlaySound, const UObject* Caller)
 {
 	if(!SkelMeshComp)
 	{
@@ -51,7 +51,7 @@ bool UFaceFXComponent::Setup(USkeletalMeshComponent* SkelMeshComp, const UFaceFX
 	if(Idx == INDEX_NONE)
 	{
 		//add new entry
-		Idx = Entries.Add(FFaceFXEntry(SkelMeshComp, Asset, IsAutoPlaySound));
+		Idx = Entries.Add(FFaceFXEntry(SkelMeshComp, AudioComponent, Asset, IsAutoPlaySound));
 	}
 	checkf(Idx != INDEX_NONE, TEXT("Internal Error: Unable to add new FaceFX entry."));
 
@@ -68,7 +68,7 @@ bool UFaceFXComponent::PlayById(FName Group, FName AnimName, USkeletalMeshCompon
 {
 #if FACEFX_USEANIMATIONLINKAGE
 
-	if(UFaceFXCharacter* Character = GetContentCharacter(SkelMeshComp))
+	if(UFaceFXCharacter* Character = GetCharacter(SkelMeshComp))
 	{
 		return Character->Play(AnimName, Group, Loop);
 	}
@@ -83,7 +83,7 @@ bool UFaceFXComponent::PlayById(FName Group, FName AnimName, USkeletalMeshCompon
 
 bool UFaceFXComponent::Play(UFaceFXAnim* Animation, USkeletalMeshComponent* SkelMeshComp, bool Loop, const UObject* Caller)
 {
-	if(UFaceFXCharacter* Character = GetContentCharacter(SkelMeshComp))
+	if(UFaceFXCharacter* Character = GetCharacter(SkelMeshComp))
 	{
 		return Character->Play(Animation, Loop);
 	}
@@ -94,7 +94,7 @@ bool UFaceFXComponent::Play(UFaceFXAnim* Animation, USkeletalMeshComponent* Skel
 
 bool UFaceFXComponent::Stop(USkeletalMeshComponent* SkelMeshComp, const UObject* Caller)
 {
-	if(UFaceFXCharacter* Character = GetContentCharacter(SkelMeshComp))
+	if(UFaceFXCharacter* Character = GetCharacter(SkelMeshComp))
 	{
 		return Character->Stop();
 	}
@@ -105,7 +105,7 @@ bool UFaceFXComponent::Stop(USkeletalMeshComponent* SkelMeshComp, const UObject*
 
 bool UFaceFXComponent::Pause(USkeletalMeshComponent* SkelMeshComp, const UObject* Caller)
 {
-	if(UFaceFXCharacter* Character = GetContentCharacter(SkelMeshComp))
+	if(UFaceFXCharacter* Character = GetCharacter(SkelMeshComp))
 	{
 		return Character->Pause();
 	}
@@ -116,7 +116,7 @@ bool UFaceFXComponent::Pause(USkeletalMeshComponent* SkelMeshComp, const UObject
 
 bool UFaceFXComponent::Resume(USkeletalMeshComponent* SkelMeshComp, const UObject* Caller)
 {
-	if(UFaceFXCharacter* Character = GetContentCharacter(SkelMeshComp))
+	if(UFaceFXCharacter* Character = GetCharacter(SkelMeshComp))
 	{
 		return Character->Resume();
 	}
@@ -125,10 +125,103 @@ bool UFaceFXComponent::Resume(USkeletalMeshComponent* SkelMeshComp, const UObjec
 	return false;
 }
 
+bool UFaceFXComponent::JumpTo(float Position, bool Pause, UFaceFXAnim* Animation, bool LoopAnimation, USkeletalMeshComponent* SkelMeshComp, const UObject* Caller)
+{
+	if(UFaceFXCharacter* Character = GetCharacter(SkelMeshComp))
+	{
+		if(!Character->IsPlayingOrPaused(Animation))
+		{
+			Character->Play(Animation, LoopAnimation);
+		}
+
+		return Character->JumpTo(Position) && (!Pause || Character->Pause());
+	}
+
+	UE_LOG(LogFaceFX, Error, TEXT("UFaceFXComponent::JumpTo. FaceFX character does not exist for given SkelMeshComp <%s>. Caller: %s"), *GetNameSafe(SkelMeshComp), *GetNameSafe(Caller));
+	return false;
+}
+
+bool UFaceFXComponent::JumpToById(float Position, bool Pause, FName Group, FName AnimName, bool LoopAnimation, USkeletalMeshComponent* SkelMeshComp, const UObject* Caller)
+{
+#if FACEFX_USEANIMATIONLINKAGE
+	if(UFaceFXCharacter* Character = GetCharacter(SkelMeshComp))
+	{
+		const FFaceFXAnimId AnimId(Group, AnimName);
+
+		if(!Character->IsPlayingOrPaused(AnimId) && !Character->Play(AnimId, LoopAnimation))
+		{
+			//new animation can't be started (most likely not found)
+			Character->Stop();
+			return false;
+		}
+
+		return Character->JumpTo(Position) && (!Pause || Character->Pause());
+	}
+
+	UE_LOG(LogFaceFX, Error, TEXT("UFaceFXComponent::JumpToById. FaceFX character does not exist for given SkelMeshComp <%s>. Caller: %s"), *GetNameSafe(SkelMeshComp), *GetNameSafe(Caller));
+#else
+	UE_LOG(LogFaceFX, Error, TEXT("UFaceFXComponent::JumpToById. Animation linkage is disabled in the FaceFX config. Use the JumpTo node instead and check FACEFX_USEANIMATIONLINKAGE. Caller: %s"), *GetNameSafe(Caller));
+#endif //FACEFX_USEANIMATIONLINKAGE
+	return false;
+}
+
+bool UFaceFXComponent::IsPlaying(USkeletalMeshComponent* SkelMeshComp, const UObject* Caller) const
+{
+	if(UFaceFXCharacter* Character = GetCharacter(SkelMeshComp))
+	{
+		return Character->IsPlaying();
+	}
+
+	UE_LOG(LogFaceFX, Error, TEXT("UFaceFXComponent::IsPlaying. FaceFX character does not exist for given SkelMeshComp <%s>. Caller: %s"), *GetNameSafe(SkelMeshComp), *GetNameSafe(Caller));
+	return false;
+}
+
+bool UFaceFXComponent::IsPaused(USkeletalMeshComponent* SkelMeshComp, const UObject* Caller) const
+{
+	if(UFaceFXCharacter* Character = GetCharacter(SkelMeshComp))
+	{
+		return Character->IsPaused();
+	}
+
+	UE_LOG(LogFaceFX, Error, TEXT("UFaceFXComponent::IsPaused. FaceFX character does not exist for given SkelMeshComp <%s>. Caller: %s"), *GetNameSafe(SkelMeshComp), *GetNameSafe(Caller));
+	return false;
+}
+
+USkeletalMeshComponent* UFaceFXComponent::GetSkelMeshTarget(const FFaceFXSkelMeshComponentId& SkelMeshId) const
+{
+	if(!SkelMeshId.IsValid())
+	{
+		return nullptr;
+	}
+
+	//first check for the index and matching name
+	if(SkelMeshId.Index < Entries.Num())
+	{
+		if(USkeletalMeshComponent* SkelMeshComp = Entries[SkelMeshId.Index].SkelMeshComp)
+		{
+			if(SkelMeshComp->GetFName() == SkelMeshId.Name)
+			{
+				return SkelMeshComp;
+			}
+		}
+	}
+
+	//if index owns a different/renamed skelmesh component we look for the name only
+	for(const FFaceFXEntry& Entry : Entries)
+	{
+		if(Entry.SkelMeshComp && Entry.SkelMeshComp->GetFName() == SkelMeshId.Name)
+		{
+			return Entry.SkelMeshComp;
+		}
+	}
+
+	return nullptr;
+}
+
 void UFaceFXComponent::OnCharacterAudioStart(UFaceFXCharacter* Character, const FFaceFXAnimId& AnimId, bool IsAudioStarted, class UAudioComponent* AudioComponentStartedOn)
 {
 	//lookup the linked entry
-	if(auto Entry = Entries.FindByKey(Character))
+	if(FFaceFXEntry* Entry = Entries.FindByKey(Character))
 	{
 		OnPlaybackAudioStart.Broadcast(Entry->SkelMeshComp, AnimId.Name, IsAudioStarted, AudioComponentStartedOn);
 	}
@@ -145,9 +238,9 @@ void UFaceFXComponent::OnCharacterPlaybackStopped(UFaceFXCharacter* Character, c
 
 void UFaceFXComponent::CreateAllCharacters()
 {
-	if(!FApp::IsGame())
+	if(FApp::IsUnattended())
 	{
-		//only create FaceFX characters while being in a game - not during cooking
+		//only create FaceFX characters while being in a game/editor - not during cooking
 		return;
 	}
 
@@ -165,9 +258,9 @@ void UFaceFXComponent::CreateCharacter(FFaceFXEntry& Entry)
 		return;
 	}
 
-	if(!FApp::IsGame())
+	if(FApp::IsUnattended())
 	{
-		//only create FaceFX characters while being in a game - not during cooking
+		//only create FaceFX characters while being in a game/editor - not during cooking
 		return;
 	}
 
@@ -190,6 +283,7 @@ void UFaceFXComponent::CreateCharacter(FFaceFXEntry& Entry)
 				Entry.Character->OnPlaybackStartAudio.AddDynamic(this, &UFaceFXComponent::OnCharacterAudioStart);
 				Entry.Character->OnPlaybackStopped.AddDynamic(this, &UFaceFXComponent::OnCharacterPlaybackStopped);
 
+				Entry.Character->SetAudioComponent(Entry.AudioComp);
 				Entry.Character->SetAutoPlaySound(Entry.bIsAutoPlaySound);
 			}
 		}

--- a/Source/FaceFX/Private/Animation/FaceFXComponent.cpp
+++ b/Source/FaceFX/Private/Animation/FaceFXComponent.cpp
@@ -103,6 +103,17 @@ bool UFaceFXComponent::Stop(USkeletalMeshComponent* SkelMeshComp, const UObject*
 	return false;
 }
 
+void UFaceFXComponent::StopAll()
+{
+	for(FFaceFXEntry& Entry : Entries)
+	{
+		if(Entry.Character)
+		{
+			Entry.Character->Stop();
+		}
+	}
+}
+
 bool UFaceFXComponent::Pause(USkeletalMeshComponent* SkelMeshComp, const UObject* Caller)
 {
 	if(UFaceFXCharacter* Character = GetCharacter(SkelMeshComp))

--- a/Source/FaceFX/Private/FaceFX.cpp
+++ b/Source/FaceFX/Private/FaceFX.cpp
@@ -24,10 +24,6 @@
 
 DEFINE_LOG_CATEGORY(LogFaceFX);
 
-/**
-* Gets the FaceFX version
-* @returns The FaceFX version string
-*/
 FString FaceFX::GetVersion()
 {
 	char ffx_version_string[32];
@@ -36,10 +32,6 @@ FString FaceFX::GetVersion()
 	return FString(ANSI_TO_TCHAR(ffx_version_string));
 }
 
-/**
-* Gets the FaceFX platform
-* @returns The FaceFX platform string
-*/
 FString FaceFX::GetPlatform()
 {
 	ffx_platform_info_t ffx_platform;
@@ -51,10 +43,6 @@ FString FaceFX::GetPlatform()
 	return FString(ANSI_TO_TCHAR(ffx_platform_string));
 }
 
-/**
-* Gets the global streamer for FaceFX assets
-* @returns The streamer
-*/
 FStreamableManager& FaceFX::GetStreamer()
 {
 	/** the global streamer for FaceFX assets */

--- a/Source/FaceFX/Private/FaceFXActor.cpp
+++ b/Source/FaceFX/Private/FaceFXActor.cpp
@@ -107,7 +107,7 @@ void UFaceFXActor::GetDetails(FString& OutDetails) const
 #if FACEFX_USEANIMATIONLINKAGE
 	//Animation references
 	TArray<FString> AnimRefs;
-	for(UFaceFXAnim* AnimRef : Animations)
+	for(const UFaceFXAnim* AnimRef : Animations)
 	{
 		if(AnimRef)
 	{
@@ -168,11 +168,11 @@ void UFaceFXActor::GetDetails(FString& OutDetails) const
 int32 UFaceFXActor::GetAnimationCount() const
 {
 	int32 Result = 0;
-	for(auto AnimSet : Animations)
+	for(const UFaceFXAnim* Animation : Animations)
 	{
-		if(AnimSet)
+		if(Animation)
 		{
-			Result += AnimSet->GetAnimationCount();
+			Result += Animation->GetAnimationCount();
 		}
 	}
 	return Result;
@@ -186,7 +186,7 @@ const UFaceFXAnim* UFaceFXActor::GetAnimation(const FName& AnimGroup, const FNam
 {
 	const bool IsNoneGroup = AnimGroup.IsNone();
 
-	for(auto Animation : Animations)
+	for(const UFaceFXAnim* Animation : Animations)
 	{
 		if(Animation && (IsNoneGroup || Animation->GetGroup() == AnimGroup))
 		{
@@ -201,11 +201,22 @@ const UFaceFXAnim* UFaceFXActor::GetAnimation(const FName& AnimGroup, const FNam
 
 void UFaceFXActor::GetAnimationGroups(TArray<FName>& OutGroups) const
 {
-	for(auto AnimSet : Animations)
+	for(const UFaceFXAnim* Animation : Animations)
 	{
-		if(AnimSet)
+		if(Animation)
 		{
-			OutGroups.AddUnique(AnimSet->GetGroup());
+			OutGroups.AddUnique(Animation->GetGroup());
+		}
+	}
+}
+
+void UFaceFXActor::GetAnimationIds(TArray<FFaceFXAnimId>& OutAnimIds) const
+{
+	for(const UFaceFXAnim* Animation : Animations)
+	{
+		if(Animation)
+		{
+			OutAnimIds.Add(Animation->GetId());
 		}
 	}
 }

--- a/Source/FaceFX/Private/FaceFXAsset.cpp
+++ b/Source/FaceFX/Private/FaceFXAsset.cpp
@@ -21,7 +21,10 @@
 #include "FaceFX.h"
 #include "FaceFXAsset.h"
 #include "FaceFXData.h"
+
+#if WITH_EDITORONLY_DATA
 #include "TargetPlatform.h"
+#endif
 
 UFaceFXAsset::UFaceFXAsset(const class FObjectInitializer& PCIP) : Super(PCIP)
 {

--- a/Source/FaceFX/Private/FaceFXCharacter.cpp
+++ b/Source/FaceFX/Private/FaceFXCharacter.cpp
@@ -86,14 +86,18 @@ bool UFaceFXCharacter::TickUntil(float Duration, bool& OutAudioStarted)
 	static const float TickSteps = 0.1F;
 
 	CurrentTime = Duration;
-	if (!Check(ffx_process_frame(ActorHandle, FrameState, 0.F)) || !Check(ffx_process_frame(ActorHandle, FrameState, CurrentTime)))
+
+	const bool ProcessZeroSuccess = Check(ffx_process_frame(ActorHandle, FrameState, 0.F));
+	const bool bIsAudioStartedAtZero = IsAudioStarted();
+
+	if (!ProcessZeroSuccess || !Check(ffx_process_frame(ActorHandle, FrameState, CurrentTime)))
 	{
 		//update failed
 		UE_LOG(LogFaceFX, Error, TEXT("UFaceFXCharacter::TickUntil. FaceFX call <ffx_process_frame> failed. %s. Asset: %s"), *GetFaceFXError(), *GetNameSafe(FaceFXActor));
 		return false;
 	}
 
-	if(IsAudioStarted())
+	if(bIsAudioStartedAtZero || IsAudioStarted())
 	{
 		OutAudioStarted = true;
 	}	

--- a/Source/FaceFX/Private/FaceFXCharacter.cpp
+++ b/Source/FaceFX/Private/FaceFXCharacter.cpp
@@ -63,7 +63,10 @@ UFaceFXCharacter::UFaceFXCharacter(const class FObjectInitializer& PCIP) : Super
 #endif
 {
 #if WITH_EDITOR
-	OnFaceFXAnimChangedHandle = UFaceFXCharacter::OnAssetChanged.AddUObject(this, &UFaceFXCharacter::OnFaceFXAssetChanged);
+	if(!IsTemplate())
+	{
+		OnFaceFXAnimChangedHandle = UFaceFXCharacter::OnAssetChanged.AddUObject(this, &UFaceFXCharacter::OnFaceFXAssetChanged);
+	}
 #endif
 }
 
@@ -965,8 +968,16 @@ void UFaceFXCharacter::OnFaceFXAssetChanged(UFaceFXAsset* Asset)
 	UFaceFXAnim* AnimAsset = Cast<UFaceFXAnim>(Asset);
 	if(Asset && (Asset == FaceFXActor || (AnimAsset && CurrentAnim == AnimAsset->GetId())))
 	{
-		//currently playing actor/anim asset changed -> stop to prevent out of sync playback
-		Stop();
+		if(UFaceFXActor* ActorAsset = Cast<UFaceFXActor>(Asset))
+		{
+			//actor asset changed -> reload whole actor
+			Load(ActorAsset);
+		}
+		else
+		{
+			//currently playing actor/anim asset changed -> stop to prevent out of sync playback
+			Stop();
+		}
 	}
 }
 #endif //WITH_EDITOR

--- a/Source/FaceFX/Private/Matinee/FaceFXMatineeControl.cpp
+++ b/Source/FaceFX/Private/Matinee/FaceFXMatineeControl.cpp
@@ -418,8 +418,6 @@ void UFaceFXMatineeControl::UpdateTrack( float NewPosition, UInterpTrackInst* Tr
 	TrackInstFaceFX->LastUpdatePosition = NewPosition;	
 }
 
-
-#if WITH_EDITORONLY_DATA
 void UFaceFXMatineeControl::DrawTrack( FCanvas* Canvas, UInterpGroup* Group, const FInterpTrackDrawParams& Params )
 {
 	static const FColor	KeySelectedColor(255,128,0);
@@ -529,7 +527,6 @@ void UFaceFXMatineeControl::DrawTrack( FCanvas* Canvas, UInterpGroup* Group, con
 		}
 	}
 }
-#endif // WITH_EDITORONLY_DATA
 
 float FFaceFXTrackKey::GetAnimationDuration(const AActor* Actor) const
 {

--- a/Source/FaceFX/Private/Matinee/FaceFXMatineeControl.cpp
+++ b/Source/FaceFX/Private/Matinee/FaceFXMatineeControl.cpp
@@ -224,6 +224,22 @@ void UFaceFXMatineeControl::PreviewUpdateTrack( float NewPosition, UInterpTrackI
 	}
 }
 
+void UFaceFXMatineeControl::PreviewStopPlayback(UInterpTrackInst* TrInst)
+{
+	check(TrInst);
+	AActor* Actor = TrInst->GetGroupActor();
+	if(!Actor)
+	{
+		return;
+	}
+
+	if(UFaceFXComponent* FaceFXComp = Actor->FindComponentByClass<UFaceFXComponent>())
+	{
+		//playback stopped
+		FaceFXComp->StopAll();
+	}
+}
+
 void UFaceFXMatineeControl::GetTrackKeyForTime(float InTime, TArray<TPair<int32, const FFaceFXTrackKey*>>& OutResult, TArray<FFaceFXSkelMeshComponentId>* OutNoTracks) const
 {
 	//build a list of all keys for all skelmesh component ids
@@ -360,7 +376,7 @@ void UFaceFXMatineeControl::UpdateTrack( float NewPosition, UInterpTrackInst* Tr
 
 			const bool IsPaused = FaceFXComp->IsPaused(SkelMeshTarget, this);
 			const bool IsPlayingOrPaused = IsPaused || FaceFXComp->IsPlaying(SkelMeshTarget, this);
-			
+
 			if(!IsPlayingOrPaused || TrackKeyPair.Key != TrackInstFaceFX->GetCurrentTrackIndex(SkelMeshTarget))
 			{
 				//start playback of a new animation

--- a/Source/FaceFX/Private/Matinee/FaceFXMatineeControl.cpp
+++ b/Source/FaceFX/Private/Matinee/FaceFXMatineeControl.cpp
@@ -1,0 +1,550 @@
+/*******************************************************************************
+  The MIT License (MIT)
+  Copyright (c) 2015 OC3 Entertainment, Inc.
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*******************************************************************************/
+
+#include "FaceFX.h"
+#include "Matinee/FaceFXMatineeControl.h"
+#include "Matinee/FaceFXMatineeControlInst.h"
+#include "Animation/FaceFXComponent.h"
+
+#include "Matinee/InterpGroup.h"
+#include "Matinee/InterpGroupInst.h"
+#include "Matinee/InterpData.h"
+#include "Matinee/MatineeActor.h"
+#include "InterpolationHitProxy.h"
+
+#define LOCTEXT_NAMESPACE "FaceFX"
+
+UFaceFXMatineeControl::UFaceFXMatineeControl(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer)
+{
+	TrackInstClass = UFaceFXMatineeControlInst::StaticClass();
+	TrackTitle = LOCTEXT("MatineeFaceFXTrack", "FaceFX Track").ToString();
+
+#if WITH_EDITORONLY_DATA
+	//TrackIcon = Cast<UTexture2D>(StaticLoadObject( UTexture2D::StaticClass(), NULL, TEXT("/Engine/EditorMaterials/MatineeGroups/MAT_Groups_Float.MAT_Groups_Float"), NULL, LOAD_None, NULL ));
+#endif // WITH_EDITORONLY_DATA
+}
+
+int32 UFaceFXMatineeControl::GetNumKeyframes() const 
+{
+	return Keys.Num();
+}
+
+float UFaceFXMatineeControl::GetTrackEndTime() const 
+{
+	return Keys.Num() ? Keys[Keys.Num() - 1].Time : 0.0f;
+}
+
+float UFaceFXMatineeControl::GetKeyframeTime( int32 KeyIndex ) const 
+{
+	if( KeyIndex < 0 || KeyIndex >= Keys.Num() )
+	{
+		return 0.f;
+	}
+	return Keys[KeyIndex].Time;
+}
+
+int32 UFaceFXMatineeControl::GetKeyframeIndex( float KeyTime ) const 
+{
+	int32 RetIndex = INDEX_NONE;
+	if( Keys.Num() > 0 )
+	{
+		float CurTime = Keys[0].Time;
+		/* Loop through every keyframe until we find a keyframe with the passed in time. */
+		/* Stop searching once all the keyframes left to search have larger times than the passed in time. */
+		for( int32 KeyIndex = 0; KeyIndex < Keys.Num() && CurTime <= KeyTime; ++KeyIndex )
+		{
+			if( KeyTime == Keys[KeyIndex].Time )
+			{
+				RetIndex = KeyIndex;
+				break;
+			}
+			CurTime = Keys[KeyIndex].Time;
+		} 
+	}
+	return RetIndex;
+}
+
+void UFaceFXMatineeControl::GetTimeRange( float& Time, float& EndTime ) const 
+{
+	if(Keys.Num() == 0)
+	{
+		Time = 0.f;
+		EndTime = 0.f;
+	}
+	else
+	{
+		Time = Keys[0].Time;
+		EndTime = Keys[ Keys.Num()-1 ].Time;
+	}
+}
+
+int32 UFaceFXMatineeControl::SetKeyframeTime( int32 KeyIndex, float NewKeyTime, bool bUpdateOrder) 
+{
+	if( KeyIndex < 0 || KeyIndex >= Keys.Num() )
+	{
+		return KeyIndex;
+	}
+	if(bUpdateOrder)
+	{
+		/* First, remove cut from track */
+		FFaceFXTrackKey MoveKey = Keys[KeyIndex];
+		Keys.RemoveAt(KeyIndex);
+		/* Set its time to the new one. */
+		MoveKey.Time = NewKeyTime;
+		/* Find correct new position and insert. */
+		int32 i=0;
+		for( i=0; i<Keys.Num() && Keys[i].Time < NewKeyTime; i++) {};
+		Keys.InsertZeroed(i);
+		Keys[i] = MoveKey;
+		return i;
+	}
+	else
+	{
+		Keys[KeyIndex].Time = NewKeyTime;
+		return KeyIndex;
+	}
+}
+
+void UFaceFXMatineeControl::RemoveKeyframe( int32 KeyIndex ) 
+{
+	if( KeyIndex < 0 || KeyIndex >= Keys.Num() )
+	{
+		return;
+	}
+	Keys.RemoveAt(KeyIndex);
+}
+
+int32 UFaceFXMatineeControl::DuplicateKeyframe( int32 KeyIndex, float NewKeyTime, UInterpTrack* ToTrack) 
+{
+	if( KeyIndex < 0 || KeyIndex >= Keys.Num() )
+	{
+		return INDEX_NONE;
+	}
+	
+	/* Make sure the destination track is specified. */
+	UFaceFXMatineeControl* DestTrack = this;
+	if ( ToTrack )
+	{
+		DestTrack = CastChecked< UFaceFXMatineeControl >( ToTrack );
+	}
+	FFaceFXTrackKey NewKey = Keys[KeyIndex];
+	NewKey.Time = NewKeyTime;
+	/* Find the correct index to insert this key. */
+	int32 i=0; for( i=0; i<DestTrack->Keys.Num() && DestTrack->Keys[i].Time < NewKeyTime; i++) {};
+	DestTrack->Keys.InsertZeroed(i);
+	DestTrack->Keys[i] = NewKey;
+	return i;
+}
+
+bool UFaceFXMatineeControl::GetClosestSnapPosition( float InPosition, TArray<int32>& IgnoreKeys, float& OutPosition ) 
+{
+	if(Keys.Num() == 0)
+	{
+		return false;
+	}
+	bool bFoundSnap = false;
+	float ClosestSnap = 0.f;
+	float ClosestDist = BIG_NUMBER;
+	for(int32 i=0; i<Keys.Num(); i++)
+	{
+		if(!IgnoreKeys.Contains(i))
+		{
+			float Dist = FMath::Abs( Keys[i].Time - InPosition );
+			if(Dist < ClosestDist)
+			{
+				ClosestSnap = Keys[i].Time;
+				ClosestDist = Dist;
+				bFoundSnap = true;
+			}
+		}
+	}
+	OutPosition = ClosestSnap;
+	return bFoundSnap;
+}
+
+int32 UFaceFXMatineeControl::AddKeyframe( float Time, UInterpTrackInst* TrackInst, EInterpCurveMode InitInterpMode ) 
+{
+	UFaceFXMatineeControlInst* TrackInstFaceFX = CastChecked<UFaceFXMatineeControlInst>(TrackInst);
+
+	FFaceFXTrackKey NewKey;
+	NewKey.Time = Time;
+
+	//insert and order by time
+	int32 i = 0; 
+	for(i = 0; i < Keys.Num() && Keys[i].Time < Time; ++i);
+	Keys.Insert(NewKey, i);
+
+	UpdateKeyframe(i, TrackInst);
+	return i;
+}
+
+
+void UFaceFXMatineeControl::PreviewUpdateTrack( float NewPosition, UInterpTrackInst* TrackInst ) 
+{
+	UInterpGroupInst* GrInst = CastChecked<UInterpGroupInst>( TrackInst->GetOuter() );
+	AMatineeActor* MatineeActor = CastChecked<AMatineeActor>( GrInst->GetOuter() );
+
+	const bool bJump = !(MatineeActor->bIsPlaying);
+
+	UpdateTrack(NewPosition, TrackInst, bJump);
+
+	if(AActor* Actor = TrackInst->GetGroupActor())
+	{
+		TInlineComponentArray<USkeletalMeshComponent*> SkelMeshComps;
+		Actor->GetComponents(SkelMeshComps);
+
+		const UFaceFXMatineeControlInst* TrackFaceFX = CastChecked<UFaceFXMatineeControlInst>(TrackInst);
+		const float TimeElapsed = (bJump || NewPosition < TrackFaceFX->LastUpdatePosition) ? 0.F : NewPosition - TrackFaceFX->LastUpdatePosition;
+
+		for(USkeletalMeshComponent* SkelMeshComp : SkelMeshComps)
+		{
+			// Update space bases so new animation position has an effect.
+			SkelMeshComp->UpdateMaterialParameters();
+			SkelMeshComp->RefreshBoneTransforms();
+			SkelMeshComp->RefreshSlaveComponents();
+			SkelMeshComp->UpdateComponentToWorld();
+		}
+	}
+}
+
+void UFaceFXMatineeControl::GetTrackKeyForTime(float InTime, TArray<TPair<int32, const FFaceFXTrackKey*>>& OutResult, TArray<FFaceFXSkelMeshComponentId>* OutNoTracks) const
+{
+	//build a list of all keys for all skelmesh component ids
+	TMap<int32, TArray<const FFaceFXTrackKey*>> SkelMeshTracks;
+	TMap<int32, FFaceFXSkelMeshComponentId> SkelMeshIds;
+	for(const FFaceFXTrackKey& Key : Keys)
+	{
+		SkelMeshTracks.FindOrAdd(Key.SkelMeshComponentId.Index).Add(&Key);
+		if(OutNoTracks && !SkelMeshIds.Contains(Key.SkelMeshComponentId.Index))
+		{
+			SkelMeshIds.Add(Key.SkelMeshComponentId.Index, Key.SkelMeshComponentId);
+		}
+	}
+
+	//then generate the pair results for each skelmesh component
+	for(auto It = SkelMeshTracks.CreateConstIterator(); It; ++It)
+	{
+		const TArray<const FFaceFXTrackKey*>& SkelMeshKeys = It.Value();
+
+		const int32 IndexMax = SkelMeshKeys.Num()-1;
+		int32 Index = INDEX_NONE;
+		for(; Index < IndexMax && SkelMeshKeys[Index+1]->Time <= InTime; ++Index);
+
+		if(Index != INDEX_NONE)
+		{
+			OutResult.Add(TPairInitializer<int32, const FFaceFXTrackKey*>(Index, SkelMeshKeys[Index]));
+		}
+		else if(OutNoTracks)
+		{
+			OutNoTracks->Add(SkelMeshIds.FindChecked(It.Key()));
+		}
+	}
+}
+
+/**
+* Loads the animation from a given track keyframe
+* @param Track The keyframe to load the animation from
+* @param Owner The owner of the potentially loaded animation data
+* @returns The loaded animation, else nullptr if not found or unset
+*/
+UFaceFXAnim* GetAnimation(const FFaceFXTrackKey& Track, UObject* Owner)
+{
+	UFaceFXAnim* NewAnim = Track.Animation.Get();
+	if(!NewAnim && Track.Animation.ToStringReference().IsValid())
+	{
+		NewAnim = Cast<UFaceFXAnim>(StaticLoadObject(UFaceFXAnim::StaticClass(), Owner, *Track.Animation.ToStringReference().ToString()));
+	}
+
+	return NewAnim;
+}
+
+void UFaceFXMatineeControl::UpdateTrack( float NewPosition, UInterpTrackInst* TrackInst, bool bJump ) 
+{
+	check(TrackInst);
+
+	AActor* Actor = TrackInst->GetGroupActor();
+	if(!Actor)
+	{
+		return;
+	}
+
+	UFaceFXComponent* FaceFXComp = Actor->FindComponentByClass<UFaceFXComponent>();
+	if(!FaceFXComp)
+	{
+		return;
+	}
+
+	UFaceFXMatineeControlInst* TrackInstFaceFX = CastChecked<UFaceFXMatineeControlInst>(TrackInst);
+
+	if(Keys.Num() == 0)
+	{
+		FaceFXComp->Stop(nullptr, this);
+	}
+	else if(NewPosition <= TrackInstFaceFX->LastUpdatePosition || bJump)
+	{
+		TArray<TPair<int32, const FFaceFXTrackKey*>> TrackKeyPairs;
+		TArray<FFaceFXSkelMeshComponentId> SkelMeshNoTracks;
+		GetTrackKeyForTime(NewPosition, TrackKeyPairs, &SkelMeshNoTracks);
+
+		for(const TPair<int32, const FFaceFXTrackKey*>& TrackKeyPair : TrackKeyPairs)
+		{
+			const FFaceFXTrackKey* TrackKey = TrackKeyPair.Value;
+
+			const float NewFaceFXAnimLocation = NewPosition - TrackKey->Time;
+			check(NewFaceFXAnimLocation >= 0.F)
+
+			USkeletalMeshComponent* SkelMeshTarget = FaceFXComp->GetSkelMeshTarget(TrackKey->SkelMeshComponentId);
+
+			//Always stop when we switch track keys to prevent playing animations when switching backward after the end of another track animation
+			//Thats because we don't check here how long the animation actually plays and rely on the JumpTo/Play functionality alone to determine that
+			if(TrackKeyPair.Key != TrackInstFaceFX->GetCurrentTrackIndex(SkelMeshTarget))
+			{
+				FaceFXComp->Stop(SkelMeshTarget);
+			}
+			TrackInstFaceFX->SetCurrentTrackIndex(SkelMeshTarget, TrackKeyPair.Key);
+
+			bool JumpSucceeded = false;
+
+			//playing backwards or jumping
+			if(TrackKey->AnimationId.IsValid())
+			{
+				//play by animation id
+				JumpSucceeded = FaceFXComp->JumpToById(NewFaceFXAnimLocation, bJump, TrackKey->AnimationId.Group, TrackKey->AnimationId.Name, TrackKey->bLoop, SkelMeshTarget, this);
+			}
+			else if(UFaceFXAnim* FaceFXAnim = GetAnimation(*TrackKey, this))
+			{
+				//play by animation
+				JumpSucceeded = FaceFXComp->JumpTo(NewFaceFXAnimLocation, bJump, FaceFXAnim, TrackKey->bLoop, SkelMeshTarget, this);
+			}
+
+			if(!JumpSucceeded)
+			{
+				//jump to failed -> i.e. out of range on non looping animation
+				FaceFXComp->Stop(SkelMeshTarget);
+			}
+		}
+
+		for(const FFaceFXSkelMeshComponentId& SkelMashNoTrack : SkelMeshNoTracks)
+		{
+			//no track key at this position for this skelmesh component -> stop
+			FaceFXComp->Stop(FaceFXComp->GetSkelMeshTarget(SkelMashNoTrack));
+		}
+	}
+	else
+	{
+		TArray<TPair<int32, const FFaceFXTrackKey*>> TrackKeyPairs;
+		GetTrackKeyForTime(NewPosition, TrackKeyPairs);
+
+		for(const TPair<int32, const FFaceFXTrackKey*>& TrackKeyPair : TrackKeyPairs)
+		{
+			const FFaceFXTrackKey* TrackKey = TrackKeyPair.Value;
+
+			USkeletalMeshComponent* SkelMeshTarget = FaceFXComp->GetSkelMeshTarget(TrackKey->SkelMeshComponentId);
+
+			const bool IsPaused = FaceFXComp->IsPaused(SkelMeshTarget, this);
+			const bool IsPlayingOrPaused = IsPaused || FaceFXComp->IsPlaying(SkelMeshTarget, this);
+			
+			if(!IsPlayingOrPaused || TrackKeyPair.Key != TrackInstFaceFX->GetCurrentTrackIndex(SkelMeshTarget))
+			{
+				//start playback of a new animation
+				
+				const float PlaybackStartPosition = NewPosition - TrackKey->Time;
+				checkf(PlaybackStartPosition >= 0.F, TEXT("Invalid animation start location"));
+
+				bool StartSucceeded = false;
+
+				//play by animation id
+				if(TrackKey->AnimationId.IsValid())
+				{
+					//play by animation id
+					StartSucceeded = FaceFXComp->JumpToById(PlaybackStartPosition, false, TrackKey->AnimationId.Group, TrackKey->AnimationId.Name, TrackKey->bLoop, SkelMeshTarget, this);
+				}
+				else if(UFaceFXAnim* FaceFXAnim = GetAnimation(*TrackKey, this))
+				{
+					//play by animation
+					//StartSucceeded = FaceFXComp->Play(FaceFXAnim, nullptr, TrackKey->bLoop, this);
+					StartSucceeded = FaceFXComp->JumpTo(PlaybackStartPosition, false, FaceFXAnim, TrackKey->bLoop, SkelMeshTarget, this);
+				}
+
+				if(!StartSucceeded)
+				{
+					//start failed -> stop
+					FaceFXComp->Stop(SkelMeshTarget);
+				}
+
+				TrackInstFaceFX->SetCurrentTrackIndex(SkelMeshTarget, TrackKeyPair.Key);
+			}
+			else if(IsPaused)
+			{
+				//resume paused animation
+				FaceFXComp->Resume(SkelMeshTarget, this);
+			}
+		}
+	}
+	
+	TrackInstFaceFX->LastUpdatePosition = NewPosition;	
+}
+
+
+#if WITH_EDITORONLY_DATA
+void UFaceFXMatineeControl::DrawTrack( FCanvas* Canvas, UInterpGroup* Group, const FInterpTrackDrawParams& Params )
+{
+	static const FColor	KeySelectedColor(255,128,0);
+	static const FColor KeyLabelColor(225,225,225);
+	static const FColor KeyBackgroundColor(0,150,200);
+	static const FColor KeyColorBlack(0,0,0);
+	static const int32	KeyVertOffset = 3;
+
+	const bool bHitTesting = Canvas->IsHitTesting();
+	const bool bAllowBarSelection = bHitTesting && Params.bAllowKeyframeBarSelection;
+	const bool bAllowTextSelection = bHitTesting && Params.bAllowKeyframeTextSelection;
+
+	AMatineeActor* MatineeActor = CastChecked<AMatineeActor>(Group->GetOuter()->GetOuter());
+	UInterpGroupInst* GroupInst = MatineeActor->FindFirstGroupInst(Group);
+	const AActor* GroupActor = GroupInst ? GroupInst->GetGroupActor() : nullptr;
+
+	//cached animation ids
+	TArray<FFaceFXAnimId> AnimIds;
+	AnimIds.AddUninitialized(Keys.Num());
+	
+	//Draw the tiles for each animation
+	for (int32 i = 0; i < Keys.Num(); i++)
+	{
+		const FFaceFXTrackKey& AnimKey = Keys[i];
+
+		FFaceFXAnimId AnimationId;
+		if(AnimKey.AnimationId.IsValid())
+		{
+			AnimationId = AnimKey.AnimationId;
+		}
+		else if(const UFaceFXAnim* Animation = GetAnimation(AnimKey, this))
+		{
+			AnimationId = Animation->GetId();
+		}
+
+		AnimIds[i] = AnimationId;
+
+		//determine animation duration
+		const float AnimStartTime = AnimKey.Time;
+		const float AnimEndTime = AnimStartTime + AnimKey.GetAnimationDuration(GroupActor);
+
+		const int32 StartPixelPos = FMath::TruncToInt((AnimStartTime - Params.StartTime) * Params.PixelsPerSec);
+		const int32 EndPixelPos = FMath::TruncToInt((AnimEndTime - Params.StartTime) * Params.PixelsPerSec);
+
+		// Find if this sound is one of the selected ones.
+		bool bKeySelected = false;
+		for (const FInterpEdSelKey& SelectedKey : Params.SelectedKeys)
+		{
+			if(SelectedKey.Group == Group && SelectedKey.Track == this && SelectedKey.KeyIndex == i)
+			{
+				bKeySelected = true;
+				break;
+			}
+		}
+
+		const FColor& BorderColor = bKeySelected ? KeySelectedColor : KeyColorBlack;
+
+		if(bAllowBarSelection) 
+		{
+			Canvas->SetHitProxy(new HInterpTrackKeypointProxy(Group, this, i));
+		}
+		Canvas->DrawTile(StartPixelPos, KeyVertOffset, EndPixelPos - StartPixelPos + 1, FMath::TruncToFloat(Params.TrackHeight - 2.f*KeyVertOffset), 0.f, 0.f, 1.f, 1.f, BorderColor);
+		Canvas->DrawTile(StartPixelPos+1, KeyVertOffset+1, EndPixelPos - StartPixelPos - 1, FMath::TruncToFloat(Params.TrackHeight - 2.f*KeyVertOffset) - 2, 0.f, 0.f, 1.f, 1.f, KeyBackgroundColor);
+		if(bAllowBarSelection)
+		{
+			Canvas->SetHitProxy(nullptr);
+		}
+	}
+	
+	// Use base-class to draw key triangles
+	Super::DrawTrack( Canvas, Group, Params );
+
+	//Draw animation names on top
+	for (int32 i = 0; i < Keys.Num(); i++)
+	{
+		const FFaceFXTrackKey& AnimKey = Keys[i];
+		
+		//fetch the cached animation id for the key
+		const FFaceFXAnimId& AnimId = AnimIds[i];
+
+		FString AnimName(TEXT("Unknown"));
+		if(AnimId.IsValid())
+		{
+			AnimName = AnimId.Group.IsNone() ? TEXT("") : AnimId.Group.ToString() + TEXT(" / ");
+			AnimName += AnimId.Name.ToString();
+		}
+
+		if(AnimKey.bLoop)
+		{
+			AnimName += TEXT(" [Looping]");
+		}
+
+		int32 XL, YL;
+		StringSize(GEngine->GetSmallFont(), XL, YL, *AnimName);
+
+		if (bAllowTextSelection)
+		{
+			Canvas->SetHitProxy(new HInterpTrackKeypointProxy(Group, this, i));
+		}
+
+		const int32 PixelPos = FMath::TruncToInt((AnimKey.Time - Params.StartTime) * Params.PixelsPerSec);
+
+		Canvas->DrawShadowedString((PixelPos + 2), Params.TrackHeight - YL - KeyVertOffset, *AnimName, GEngine->GetSmallFont(), KeyLabelColor);
+		if (bAllowTextSelection)
+		{
+			Canvas->SetHitProxy(nullptr);
+		}
+	}
+}
+#endif // WITH_EDITORONLY_DATA
+
+float FFaceFXTrackKey::GetAnimationDuration(const AActor* Actor) const
+{
+	if(!bIsAnimationDurationLoaded)
+	{
+#if FACEFX_USEANIMATIONLINKAGE
+		//try to resolve the animation duration
+		if(AnimationId.IsValid() && Actor)
+		{
+			//resolve by animtion id
+			float AnimStart, AnimEnd;
+			if(UFaceFXCharacter::GetAnimationBoundsById(Actor, AnimationId, AnimStart, AnimEnd))
+			{
+				AnimationDuration = AnimEnd - AnimStart;
+			}
+		}
+		else 
+#endif //FACEFX_USEANIMATIONLINKAGE
+		if(UFaceFXAnim* Animation = GetAnimation(*this, nullptr))
+		{
+			//resolve by animation asset
+			float AnimStart, AnimEnd;
+			if(UFaceFXCharacter::GetAnimationBounds(Animation, AnimStart, AnimEnd))
+			{
+				AnimationDuration = AnimEnd - AnimStart;
+			}
+		}
+
+		bIsAnimationDurationLoaded = true;
+	}
+	return AnimationDuration;
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/FaceFX/Private/Matinee/FaceFXMatineeControlInst.cpp
+++ b/Source/FaceFX/Private/Matinee/FaceFXMatineeControlInst.cpp
@@ -20,6 +20,7 @@
 
 #include "FaceFX.h"
 #include "Matinee/FaceFXMatineeControlInst.h"
+#include "Animation/FaceFXComponent.h"
 
 #include "Matinee/InterpGroupInst.h"
 #include "Matinee/MatineeActor.h"
@@ -35,4 +36,18 @@ void UFaceFXMatineeControlInst::InitTrackInst(UInterpTrack* Track)
 	AMatineeActor* MatineeActor = CastChecked<AMatineeActor>( GrInst->GetOuter() );
 
 	LastUpdatePosition = MatineeActor->InterpPosition;
+}
+
+void UFaceFXMatineeControlInst::RestoreActorState(UInterpTrack* Track)
+{
+	UInterpGroupInst* GrInst = CastChecked<UInterpGroupInst>( GetOuter() );
+	
+	//called when matinee closes. In that case we stop any running animation/sounds
+	if(const AActor* GroupActor = GrInst->GetGroupActor())
+	{
+		if(UFaceFXComponent* FaceFXComp = GroupActor->FindComponentByClass<UFaceFXComponent>())
+		{
+			FaceFXComp->StopAll();
+		}
+	}
 }

--- a/Source/FaceFX/Private/Matinee/FaceFXMatineeControlInst.cpp
+++ b/Source/FaceFX/Private/Matinee/FaceFXMatineeControlInst.cpp
@@ -18,34 +18,21 @@
   SOFTWARE.
 *******************************************************************************/
 
-using UnrealBuildTool;
+#include "FaceFX.h"
+#include "Matinee/FaceFXMatineeControlInst.h"
 
-public class FaceFXEditor : ModuleRules
+#include "Matinee/InterpGroupInst.h"
+#include "Matinee/MatineeActor.h"
+
+UFaceFXMatineeControlInst::UFaceFXMatineeControlInst(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer), 
+	LastUpdatePosition(0.F)
 {
-    public FaceFXEditor(TargetInfo Target)
-    {
-        PrivateDependencyModuleNames.AddRange(
-            new string[] {
-                "Core",
-                "CoreUObject",
-                "Engine",
-                "UnrealEd",
-                "EditorStyle",
-                "Slate",
-                "SlateCore",
-                "InputCore",
-                "AssetTools",
-                "AssetRegistry",
-                "ContentBrowser",
-                "MainFrame",
-                "DesktopPlatform",
-                "AnimGraph",
-                "BlueprintGraph",
-                "Matinee",
-                "FaceFX"
-            }
-        );
+}
 
-        DynamicallyLoadedModuleNames.Add("AssetTools");
-    }
+void UFaceFXMatineeControlInst::InitTrackInst(UInterpTrack* Track)
+{
+	UInterpGroupInst* GrInst = CastChecked<UInterpGroupInst>( GetOuter() );
+	AMatineeActor* MatineeActor = CastChecked<AMatineeActor>( GrInst->GetOuter() );
+
+	LastUpdatePosition = MatineeActor->InterpPosition;
 }

--- a/Source/FaceFXEditor/Classes/Matinee/FaceFXMatineeControlHelper.h
+++ b/Source/FaceFXEditor/Classes/Matinee/FaceFXMatineeControlHelper.h
@@ -1,0 +1,142 @@
+/*******************************************************************************
+  The MIT License (MIT)
+  Copyright (c) 2015 OC3 Entertainment, Inc.
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*******************************************************************************/
+
+#pragma once
+
+class UInterpTrack;
+class UInterpGroup;
+
+#include "FaceFXConfig.h"
+#if FACEFX_USEANIMATIONLINKAGE
+#include "FaceFXData.h"
+#endif //FACEFX_USEANIMATIONLINKAGE
+
+#include "InterpTrackHelper.h"
+#include "FaceFXMatineeControlHelper.generated.h"
+
+/** Interp helper functionalities for the key frame/track creation handling */
+UCLASS()
+class UFaceFXMatineeControlHelper : public UInterpTrackHelper
+{
+	GENERATED_UCLASS_BODY()
+
+	//UInterpTrackHelper
+	virtual	bool PreCreateTrack( UInterpGroup* Group, const UInterpTrack *TrackDef, bool bDuplicatingTrack, bool bAllowPrompts ) const override;
+	virtual	bool PreCreateKeyframe( UInterpTrack *Track, float KeyTime ) const override;
+	virtual void PostCreateKeyframe( UInterpTrack *Track, int32 KeyIndex ) const override;
+	//~UInterpTrackHelper
+
+private:
+
+	/** Resets the cached values */
+	inline void ResetCachedValues() const
+	{
+		KeyframeAddFaceFXAnim = nullptr;
+#if FACEFX_USEANIMATIONLINKAGE
+		KeyframeAddFaceFXAnimId.Reset();
+#endif //FACEFX_USEANIMATIONLINKAGE
+		KeyframeAddSkelMeshComponentId.Reset();
+		bKeyframeSettingsLoop = false;
+	}
+
+	/** 
+	* Event callback for when the FaceFX anim asset was selected 
+	* @param AssetData The asset selection data
+	* @param Matinee The matinee instance
+	* @param Track THe track for which the asset was selected
+	*/
+	void OnAnimAssetSelected(const class FAssetData& AssetData, class IMatineeBase* Matinee, UInterpTrack* Track);
+
+	/** 
+	* Event callback for when the keyframe loop setting checkbox got (un)checked
+	* @param NewState The new state of the checkbox
+	*/
+	void OnKeyframeLoopCheckboxChange(ECheckBoxState NewState);
+
+	/** 
+	* Event callback for when the user selected an skelmesh component from the combo box
+	* @param NewSelection The new selection
+	* @param SelectInfo The selection info
+	* @param Matinee The matinee instance
+	* @param Track THe track for which the asset was selected
+	*/
+	void OnSkelMeshComboBoxSelected(TSharedPtr<struct FFaceFXSkelMeshSelection> NewSelection, enum ESelectInfo::Type SelectInfo, class IMatineeBase* Matinee, UInterpTrack* Track);
+
+	/** Creates the widget for the skelmesh selection combo box entry */
+	TSharedRef<SWidget> MakeWidgetFromSkelMeshSelection(TSharedPtr<struct FFaceFXSkelMeshSelection> InItem);
+
+#if FACEFX_USEANIMATIONLINKAGE
+	/** 
+	* Event callback when the FaceFX animation group was selected
+	* @param Text The committed text
+	* @param Type The commit type
+	* @param Matinee The matinee instance
+	* @param Track THe track for which the asset was selected
+	*/
+	void OnAnimGroupCommitted(const FText& Text, ETextCommit::Type Type, class IMatineeBase* Matinee, UInterpTrack* Track);
+
+	/** 
+	* Event callback when the FaceFX animation id was selected
+	* @param Text The committed text
+	* @param Type The commit type
+	* @param Matinee The matinee instance
+	* @param Track THe track for which the asset was selected
+	*/
+	void OnAnimIdCommitted(const FText& Text, ETextCommit::Type Type, class IMatineeBase* Matinee, UInterpTrack* Track);
+
+	/** Creates the widget for the animation id combo box entry */
+	TSharedRef<SWidget> MakeWidgetFromAnimId(TSharedPtr<FFaceFXAnimId> InItem);
+
+	/** 
+	* Event callback for when the user selected an animation id from the combo box
+	* @param NewSelection The new selection
+	* @param SelectInfo The selection info
+	* @param Matinee The matinee instance
+	* @param Track THe track for which the asset was selected
+	*/
+	void OnAnimIdComboBoxSelected(TSharedPtr<FFaceFXAnimId> NewSelection, enum ESelectInfo::Type SelectInfo, class IMatineeBase* Matinee, UInterpTrack* Track);
+
+	/** The FaceFX animation id that is currently being added */
+	mutable FFaceFXAnimId KeyframeAddFaceFXAnimId;
+
+	/** The animation id combo box entries */
+	mutable TArray<TSharedPtr<FFaceFXAnimId>> KeyframeAddFaceDXExistingAnimIds;
+
+#endif //FACEFX_USEANIMATIONLINKAGE
+
+	/** */
+	mutable TSharedPtr<class STextBlock> SkelMeshComponentSelection;
+
+	/** The combo box entries for the skel mesh combo box */
+	mutable TArray<TSharedPtr<struct FFaceFXSkelMeshSelection>> SkelMeshSelectionComboBoxEntries;
+
+	/** The FaceFX animation that is currently being added */
+	UPROPERTY()
+	mutable class UFaceFXAnim* KeyframeAddFaceFXAnim;
+
+	/** The currently selected skel mesh component */
+	mutable FFaceFXSkelMeshComponentId KeyframeAddSkelMeshComponentId;
+
+	/** The last popup window that was opened */
+	mutable TWeakPtr<class SWindow> EntryPopupWindow;
+
+	/** Indicator if the keyframe that is about to get created shall loop the animation */
+	mutable uint8 bKeyframeSettingsLoop : 1;
+};

--- a/Source/FaceFXEditor/Private/AssetTypeActions/AssetTypeActions_FaceFXActor.cpp
+++ b/Source/FaceFXEditor/Private/AssetTypeActions/AssetTypeActions_FaceFXActor.cpp
@@ -237,7 +237,7 @@ void FAssetTypeActions_FaceFXActor::OpenAssetEditor( const TArray<UObject*>& InO
 			FString ErrMsg;
 			if(!FFaceFXEditorTools::OpenFaceFXStudio(FaceFXActor, &ErrMsg))
 			{
-				ShowError(FText::FromString(ErrMsg));
+				FFaceFXEditorTools::ShowError(FText::FromString(ErrMsg));
 				bAnyError = true;
 			}
 		}
@@ -245,7 +245,7 @@ void FAssetTypeActions_FaceFXActor::OpenAssetEditor( const TArray<UObject*>& InO
 
 	if(!bAnyError)
 	{
-		ShowInfo(LOCTEXT("Asset_OpenAsset","Opening asset(s) in background process successfully completed."));
+		FFaceFXEditorTools::ShowInfo(LOCTEXT("Asset_OpenAsset","Opening asset(s) in background process successfully completed."));
 	}
 }
 

--- a/Source/FaceFXEditor/Private/AssetTypeActions/AssetTypeActions_FaceFXBase.cpp
+++ b/Source/FaceFXEditor/Private/AssetTypeActions/AssetTypeActions_FaceFXBase.cpp
@@ -30,40 +30,12 @@
 #include "ModuleManager.h"
 #include "DesktopPlatformModule.h"
 #include "ContentBrowserModule.h"
-#include "SNotificationList.h"
-#include "NotificationManager.h"
 
 #define LOCTEXT_NAMESPACE "FaceFX"
 
 uint32 FAssetTypeActions_FaceFXBase::GetCategories() 
 { 
 	return FFaceFXEditorTools::AssetCategory; 
-}
-
-/** 
-* Shows a slate error message
-* @param Msg The error message to show
-*/
-void FAssetTypeActions_FaceFXBase::ShowError(const FText& Msg)
-{
-	FNotificationInfo Info(Msg);
-	Info.ExpireDuration = 10.F;
-	Info.bUseLargeFont = false;
-	Info.Image = FEditorStyle::GetBrush(TEXT("MessageLog.Error"));
-	FSlateNotificationManager::Get().AddNotification(Info);
-}
-
-/** 
-* Shows a slate info message
-* @param Msg The info message to show
-*/
-void FAssetTypeActions_FaceFXBase::ShowInfo(const FText& Msg)
-{
-	FNotificationInfo Info(Msg);
-	Info.ExpireDuration = 10.F;
-	Info.bUseLargeFont = false;
-	Info.Image = FEditorStyle::GetBrush(TEXT("Icons.Info"));
-	FSlateNotificationManager::Get().AddNotification(Info);
 }
 
 /** Determine if we can recompile assets */
@@ -97,7 +69,7 @@ void FAssetTypeActions_FaceFXBase::ExecuteSetSource(TArray<TWeakObjectPtr<UObjec
 	if(Objects.Num() == 0)
 	{
 		//failure
-		ShowError(LOCTEXT("SetSourceFailedMissing","Missing asset."));
+		FFaceFXEditorTools::ShowError(LOCTEXT("SetSourceFailedMissing","Missing asset."));
 		return;
 	}
 
@@ -105,7 +77,7 @@ void FAssetTypeActions_FaceFXBase::ExecuteSetSource(TArray<TWeakObjectPtr<UObjec
 	if(!FaceFXAsset)
 	{
 		//failure
-		ShowError(LOCTEXT("SetSourceFailedInvalid","Invalid asset type."));
+		FFaceFXEditorTools::ShowError(LOCTEXT("SetSourceFailedInvalid","Invalid asset type."));
 		return;
 	}
 
@@ -127,7 +99,7 @@ void FAssetTypeActions_FaceFXBase::ExecuteSetSource(TArray<TWeakObjectPtr<UObjec
 		if(Files.Num() <= 0)
 		{
 			//no file selected
-			ShowError(LOCTEXT("SetSourceFailedCancelled", "FaceFX asset selection cancelled."));
+			FFaceFXEditorTools::ShowError(LOCTEXT("SetSourceFailedCancelled", "FaceFX asset selection cancelled."));
 			return;
 		}
 
@@ -154,7 +126,7 @@ void FAssetTypeActions_FaceFXBase::ExecuteSetSource(TArray<TWeakObjectPtr<UObjec
 	else
 	{
 		//failure
-		ShowError(LOCTEXT("SetSourceFailedPlatform","Unable to fetch desktop platform module."));
+		FFaceFXEditorTools::ShowError(LOCTEXT("SetSourceFailedPlatform","Unable to fetch desktop platform module."));
 	}
 }
 
@@ -262,7 +234,7 @@ void FAssetTypeActions_FaceFXBase::ExecuteOpenFolder(TArray<TWeakObjectPtr<UObje
 	if(!Errors.IsEmpty())
 	{
 		//we have some errors
-		ShowError(FText::FromString(Errors));
+		FFaceFXEditorTools::ShowError(FText::FromString(Errors));
 	}
 }
 

--- a/Source/FaceFXEditor/Private/AssetTypeActions/AssetTypeActions_FaceFXBase.h
+++ b/Source/FaceFXEditor/Private/AssetTypeActions/AssetTypeActions_FaceFXBase.h
@@ -57,18 +57,6 @@ protected:
 	/** Determine if we can open the source asset folder */
 	bool CanExecuteOpenFolder(const TArray<UObject*> Objects) const;
 
-	/** 
-	* Shows a slate error message
-	* @param msg The error message to show
-	*/
-	static void ShowError(const FText& Msg);
-
-	/** 
-	* Shows a slate info message
-	* @param msg The info message to show
-	*/
-	static void ShowInfo(const FText& Msg);
-
 private:
 
 	/** Callback function for before the compilation folder gets deleted */

--- a/Source/FaceFXEditor/Private/FaceFXEditorTools.cpp
+++ b/Source/FaceFXEditor/Private/FaceFXEditorTools.cpp
@@ -37,6 +37,8 @@
 #include "ContentBrowserModule.h"
 #include "Sound/SoundWave.h"
 #include "Editor.h"
+#include "SNotificationList.h"
+#include "NotificationManager.h"
 
 #define LOCTEXT_NAMESPACE "FaceFX"
 
@@ -1225,6 +1227,24 @@ void FFaceFXEditorTools::DeleteAsset(UObject* Asset)
 	TArray<UObject*> Objects;
 	Objects.Add(Asset);
 	ObjectTools::ForceDeleteObjects(Objects, false);
+}
+
+void FFaceFXEditorTools::ShowError(const FText& Msg)
+{
+	FNotificationInfo Info(Msg);
+	Info.ExpireDuration = 10.F;
+	Info.bUseLargeFont = false;
+	Info.Image = FEditorStyle::GetBrush(TEXT("MessageLog.Error"));
+	FSlateNotificationManager::Get().AddNotification(Info);
+}
+
+void FFaceFXEditorTools::ShowInfo(const FText& Msg)
+{
+	FNotificationInfo Info(Msg);
+	Info.ExpireDuration = 10.F;
+	Info.bUseLargeFont = false;
+	Info.Image = FEditorStyle::GetBrush(TEXT("Icons.Info"));
+	FSlateNotificationManager::Get().AddNotification(Info);
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/FaceFXEditor/Private/FaceFXEditorTools.cpp
+++ b/Source/FaceFXEditor/Private/FaceFXEditorTools.cpp
@@ -694,6 +694,11 @@ UFaceFXAnim* FFaceFXEditorTools::ReimportOrCreateAnimAsset(const FString& Compil
 				OutResultMessages.AddModifySuccess(LOCTEXT("CreateAssetAnimExistSuccess", "Reimported already existing animation Asset."), ExistingAnim);
 #endif //FACEFX_USEANIMATIONLINKAGE
 	
+				SavePackage(ExistingAnim->GetOutermost());
+
+				//inform FaceFX characters about updated asset
+				UFaceFXCharacter::OnAssetChanged.Broadcast(ExistingAnim);
+
 				return ExistingAnim;
 			}
 			else
@@ -727,6 +732,9 @@ UFaceFXAnim* FFaceFXEditorTools::ReimportOrCreateAnimAsset(const FString& Compil
 #endif //FACEFX_USEANIMATIONLINKAGE
 
 			SavePackage(NewAsset->GetOutermost());
+
+			//inform FaceFX characters about updated asset
+			UFaceFXCharacter::OnAssetChanged.Broadcast(NewAsset);
 
 			return NewAsset;
 		}

--- a/Source/FaceFXEditor/Private/FaceFXEditorTools.cpp
+++ b/Source/FaceFXEditor/Private/FaceFXEditorTools.cpp
@@ -476,6 +476,9 @@ bool FFaceFXEditorTools::ImportFaceFXAsset(UFaceFXAsset* Asset, const FString& A
 	CleanupCompilationFolder(CompilationFolder);
 #endif //FACEFX_DELETE_EMPTY_COMPILATION_FOLDER
 
+	//inform FaceFX characters about updated asset
+	UFaceFXCharacter::OnAssetChanged.Broadcast(Asset);
+
 	return ImportResult;
 }
 

--- a/Source/FaceFXEditor/Private/Factories/FaceFXActorFactory.cpp
+++ b/Source/FaceFXEditor/Private/Factories/FaceFXActorFactory.cpp
@@ -31,8 +31,6 @@
 #include "ObjectTools.h"
 #include "ISourceControlModule.h"
 #include "Editor.h"
-#include "SNotificationList.h"
-#include "NotificationManager.h"
 #include "Include/Slate/FaceFXResultWidget.h"
 
 #define LOCTEXT_NAMESPACE "FaceFX"
@@ -46,32 +44,6 @@ UFaceFXActorFactory::UFaceFXActorFactory(const class FObjectInitializer& PCIP)
 	bText = false;
 
 	Formats.Add(TEXT("facefx;FaceFX Asset"));
-}
-
-/**
-* Shows an error notification message
-* @param msg The message to show
-*/
-void ShowError(const FText& Msg)
-{
-	FNotificationInfo Info(Msg);
-	Info.ExpireDuration = 10.F;
-	Info.bUseLargeFont = false;
-	Info.Image = FEditorStyle::GetBrush(TEXT("MessageLog.Error"));
-	FSlateNotificationManager::Get().AddNotification(Info);
-}
-
-/**
-* Shows an info notification message
-* @param msg The message to show
-*/
-void ShowInfo(const FText& Msg)
-{
-	FNotificationInfo Info(Msg);
-	Info.ExpireDuration = 10.F;
-	Info.bUseLargeFont = false;
-	Info.Image = FEditorStyle::GetBrush(TEXT("Icons.Info"));
-	FSlateNotificationManager::Get().AddNotification(Info);
 }
 
 UObject* UFaceFXActorFactory::FactoryCreateNew(UClass* InClass, UObject* InParent, FName InName, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn)
@@ -181,7 +153,7 @@ UObject* UFaceFXActorFactory::CreateNew(UClass* Class, UObject* InParent, const 
 			if(Files.Num() <= 0)
 			{
 				//no file selected
-				ShowError(LOCTEXT("CreateFail", "Import of FaceFX asset cancelled."));
+				FFaceFXEditorTools::ShowError(LOCTEXT("CreateFail", "Import of FaceFX asset cancelled."));
 				return nullptr;
 			}
 			FaceFXAsset = Files[0];
@@ -189,7 +161,7 @@ UObject* UFaceFXActorFactory::CreateNew(UClass* Class, UObject* InParent, const 
 		}
 		else
 		{
-			ShowError(LOCTEXT("CreateFail", "Internal Error: Retrieving platform module failed."));
+			FFaceFXEditorTools::ShowError(LOCTEXT("CreateFail", "Internal Error: Retrieving platform module failed."));
 			return nullptr;
 		}
 	}
@@ -218,7 +190,7 @@ UObject* UFaceFXActorFactory::CreateNew(UClass* Class, UObject* InParent, const 
 	}
 	else
 	{
-		ShowError(LOCTEXT("CreateFail", "Import failed. FaceFX asset missing."));
+		FFaceFXEditorTools::ShowError(LOCTEXT("CreateFail", "Import failed. FaceFX asset missing."));
 	}
 
 	return nullptr;

--- a/Source/FaceFXEditor/Private/Matinee/FaceFXMatineeControlHelper.cpp
+++ b/Source/FaceFXEditor/Private/Matinee/FaceFXMatineeControlHelper.cpp
@@ -1,0 +1,427 @@
+/*******************************************************************************
+  The MIT License (MIT)
+  Copyright (c) 2015 OC3 Entertainment, Inc.
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*******************************************************************************/
+
+#include "FaceFXEditor.h"
+#include "Matinee/FaceFXMatineeControlHelper.h"
+#include "Matinee/FaceFXMatineeControl.h"
+#include "Animation/FaceFXComponent.h"
+#include "FaceFXCharacter.h"
+
+#include "Editor.h"
+#include "SlateCore.h"
+#include "SlateBasics.h"
+#include "STextEntryPopup.h"
+#include "EditorViewportClient.h"
+#include "IMatinee.h"
+#include "Matinee/MatineeActor.h"
+#include "Matinee/InterpGroupInst.h"
+#include "EditorModeInterpolation.h"
+#include "FaceFXAnim.h"
+#include "ContentBrowserModule.h"
+#include "SNotificationList.h"
+#include "NotificationManager.h"
+
+#define LOCTEXT_NAMESPACE "FaceFX"
+
+/** A single combo box item for the skel mesh selection */
+struct FFaceFXSkelMeshSelection
+{
+	/** The character skel mesh component id */
+	FFaceFXSkelMeshComponentId Id;
+
+	/** The text to display on the combo box */
+	FString Text;
+};
+
+UFaceFXMatineeControlHelper::UFaceFXMatineeControlHelper(const FObjectInitializer& ObjectInitializer)
+	: Super(ObjectInitializer), KeyframeAddFaceFXAnim(nullptr), bKeyframeSettingsLoop(false)
+{	
+}
+
+bool UFaceFXMatineeControlHelper::PreCreateTrack( UInterpGroup* Group, const UInterpTrack *TrackDef, bool bDuplicatingTrack, bool bAllowPrompts ) const
+{
+	FEdModeInterpEdit* Mode = static_cast<FEdModeInterpEdit*>(GLevelEditorModeTools().GetActiveMode( FBuiltinEditorModes::EM_InterpEdit ));
+	check(Mode);
+
+	IMatineeBase* InterpEd = Mode->InterpEd;
+	check(InterpEd);
+
+	UInterpGroupInst* GrInst = InterpEd->GetMatineeActor()->FindFirstGroupInst(Group);
+	check(GrInst);
+
+	if (AActor* Actor = GrInst->GetGroupActor())
+	{
+		//Locate FaceFX component
+		if(!Actor->FindComponentByClass<UFaceFXComponent>())
+		{
+			UE_LOG(LogFaceFX, Warning, TEXT("InterpGroup : FaceFX component missing (%s)"), *Actor->GetName());
+
+			if(bAllowPrompts)
+			{
+				FNotificationInfo Info(LOCTEXT("MatineeFaceFXMissingComponent", "Unable to add FaceFX Track. Selected actor does not own a FaceFX Component."));
+				Info.ExpireDuration = 10.F;
+				Info.bUseLargeFont = false;
+				Info.Image = FEditorStyle::GetBrush(TEXT("MessageLog.Error"));
+				FSlateNotificationManager::Get().AddNotification(Info);
+			}
+
+			return false;
+		}
+	}
+	return true;
+}
+
+bool UFaceFXMatineeControlHelper::PreCreateKeyframe( UInterpTrack *Track, float fTime ) const
+{
+	ResetCachedValues();
+
+	UFaceFXMatineeControl* TrackFaceFX = CastChecked<UFaceFXMatineeControl>(Track);
+	UInterpGroup* Group = CastChecked<UInterpGroup>(TrackFaceFX->GetOuter());
+
+	AActor* Actor = GetGroupActor(Track);
+	if (!Actor)
+	{
+		// error message
+		UE_LOG(LogFaceFX, Warning, TEXT("No Actor is selected. Select actor first."));
+		return false;
+	}
+
+	UFaceFXComponent* FaceFXComponent = Actor->FindComponentByClass<UFaceFXComponent>();
+	if (!FaceFXComponent)
+	{
+		UE_LOG(LogFaceFX, Warning, TEXT("FaceFX Component isn't found in the selected actor: %s"), *GetNameSafe(Actor));
+		return false;
+	}
+
+	// Show the dialog.
+	FEdModeInterpEdit* Mode = (FEdModeInterpEdit*)GLevelEditorModeTools().GetActiveMode( FBuiltinEditorModes::EM_InterpEdit );
+	check(Mode);
+	check(Mode->InterpEd);
+
+	TSharedPtr< SWindow > Parent = FSlateApplication::Get().GetActiveTopLevelWindow();
+	if ( Parent.IsValid() )
+	{
+		FAssetPickerConfig AssetPickerConfig;
+		AssetPickerConfig.OnAssetSelected = FOnAssetSelected::CreateUObject(this, &UFaceFXMatineeControlHelper::OnAnimAssetSelected, Mode->InterpEd, Track);
+		AssetPickerConfig.bAllowNullSelection = false;
+		AssetPickerConfig.InitialAssetViewType = EAssetViewType::List;
+		AssetPickerConfig.Filter.ClassNames.Add(UFaceFXAnim::StaticClass()->GetFName());
+
+		FContentBrowserModule& ContentBrowserModule = FModuleManager::Get().LoadModuleChecked<FContentBrowserModule>(TEXT("ContentBrowser"));
+
+		FMenuBuilder MenuBuilder(true, nullptr);
+
+		TSharedPtr<SComboBox<TSharedPtr<FFaceFXSkelMeshSelection>>> SkelMeshSelectionComboBox;
+
+		//Add animation specification by using the asset selection
+		MenuBuilder.BeginSection(NAME_None, LOCTEXT("MatineeFaceFXKeySettings", "FaceFX Animation Settings"));
+		{
+			TSharedPtr<SVerticalBox> MenuEntry = 
+				SNew(SVerticalBox)
+				+SVerticalBox::Slot()
+				.AutoHeight()
+				[
+					SNew(SCheckBox)
+					.OnCheckStateChanged(FOnCheckStateChanged::CreateUObject(this, &UFaceFXMatineeControlHelper::OnKeyframeLoopCheckboxChange))
+					[
+						SNew(STextBlock)
+						.Text(LOCTEXT("MatineeFaceFXKeySettingsLoop", "Loop Animation"))
+					]
+				]
+				+SVerticalBox::Slot()
+				.AutoHeight()
+				[
+					SNew(SBorder)
+					. BorderImage(FCoreStyle::Get().GetBrush("PopupText.Background"))
+					. Padding(10)
+					[
+						SNew(SHorizontalBox)
+						+SHorizontalBox::Slot()
+						.AutoWidth()
+						[
+							SNew(STextBlock)
+							.Text(LOCTEXT("MatineeFaceFXKeySkelMeshSelectionTitle", "Target Skeletal Mesh Component: "))
+						]
+						+SHorizontalBox::Slot()
+						.AutoWidth()
+						[
+							SAssignNew(SkelMeshSelectionComboBox, SComboBox<TSharedPtr<FFaceFXSkelMeshSelection>>)
+							.OptionsSource(&SkelMeshSelectionComboBoxEntries)
+							.OnGenerateWidget(SComboBox<TSharedPtr<FFaceFXSkelMeshSelection>>::FOnGenerateWidget::CreateUObject(this, &UFaceFXMatineeControlHelper::MakeWidgetFromSkelMeshSelection))
+							.OnSelectionChanged(SComboBox<TSharedPtr<FFaceFXSkelMeshSelection>>::FOnSelectionChanged::CreateUObject(this, &UFaceFXMatineeControlHelper::OnSkelMeshComboBoxSelected, Mode->InterpEd, Track))
+							[
+								SAssignNew(SkelMeshComponentSelection, STextBlock)
+								.Text(LOCTEXT("MatineeFaceFXKeySkelMeshSelectionDefaultTitle", "<Default>"))
+							]
+						]
+					]
+				];
+			MenuBuilder.AddWidget(MenuEntry.ToSharedRef(), FText::GetEmpty(), true);
+
+			//Fill Skel mesh component list
+			SkelMeshSelectionComboBoxEntries.Reset();
+			
+			TArray<USkeletalMeshComponent*> SkelMeshComponents;
+			FaceFXComponent->GetSetupSkelMeshComponents(SkelMeshComponents);
+
+			//Add default entry
+			FFaceFXSkelMeshSelection* NewEntry = new FFaceFXSkelMeshSelection();
+			NewEntry->Text = LOCTEXT("MatineeFaceFXKeySkelMeshSelectionDefaultTitle", "<Default>").ToString();
+			SkelMeshSelectionComboBoxEntries.Add(MakeShareable(NewEntry));
+
+			for(int32 i=0; i<SkelMeshComponents.Num(); ++i)
+			{
+				const USkeletalMeshComponent* SkelMeshComp = SkelMeshComponents[i];
+
+				NewEntry = new FFaceFXSkelMeshSelection();
+				NewEntry->Id.Index = i;
+				NewEntry->Id.Name = SkelMeshComp->GetFName();
+				if(SkelMeshComp)
+				{
+					NewEntry->Text = SkelMeshComp->GetName();
+					if(SkelMeshComp->SkeletalMesh)
+					{
+						NewEntry->Text += TEXT("  [Mesh: ") + SkelMeshComp->SkeletalMesh->GetName() + TEXT("]");
+					}
+				}
+				else
+				{
+					NewEntry->Text = TEXT("Unknown");
+				}
+
+				SkelMeshSelectionComboBoxEntries.Add(MakeShareable(NewEntry));
+			}
+			SkelMeshSelectionComboBox->RefreshOptions();
+		}
+		MenuBuilder.EndSection();
+
+#if FACEFX_USEANIMATIONLINKAGE
+
+		//Add animation specification by using the animation ID
+		MenuBuilder.BeginSection(NAME_None, LOCTEXT("MatineeFaceFXKeyAnimID", "Play By FaceFX Animation ID"));
+
+		TSharedPtr<SComboBox<TSharedPtr<FFaceFXAnimId>>> AnimIdComboBox;
+
+		//Add a text input field for the animation ID specifier in case animation linkage is enabled
+		TSharedPtr<SVerticalBox> MenuEntry = 
+			SNew(SVerticalBox)
+			+SVerticalBox::Slot()
+			.AutoHeight()
+			[
+				SNew(STextEntryPopup)
+				.Label(LOCTEXT("MatineeFaceFXKeyAnimGroupTitle", "Animation Group"))
+				.OnTextCommitted(FOnTextCommitted::CreateUObject(this, &UFaceFXMatineeControlHelper::OnAnimGroupCommitted, Mode->InterpEd, Track))
+			]
+			+SVerticalBox::Slot()
+			.AutoHeight()
+			[
+				SNew(STextEntryPopup)
+				.Label(LOCTEXT("MatineeFaceFXKeyAnimIDTitle", "Animation Id"))
+				.OnTextCommitted(FOnTextCommitted::CreateUObject(this, &UFaceFXMatineeControlHelper::OnAnimIdCommitted, Mode->InterpEd, Track))
+			]
+			+SVerticalBox::Slot()
+			.AutoHeight()
+			[
+				SNew(SBorder)
+				. BorderImage(FCoreStyle::Get().GetBrush("PopupText.Background"))
+				. Padding(10)
+				[
+					SAssignNew(AnimIdComboBox, SComboBox<TSharedPtr<FFaceFXAnimId>>)
+					.OptionsSource(&KeyframeAddFaceDXExistingAnimIds)
+					.OnGenerateWidget(SComboBox<TSharedPtr<FFaceFXAnimId>>::FOnGenerateWidget::CreateUObject(this, &UFaceFXMatineeControlHelper::MakeWidgetFromAnimId))
+					.OnSelectionChanged(SComboBox<TSharedPtr<FFaceFXAnimId>>::FOnSelectionChanged::CreateUObject(this, &UFaceFXMatineeControlHelper::OnAnimIdComboBoxSelected, Mode->InterpEd, Track))
+					[
+						SNew(STextBlock)
+						.Text(LOCTEXT("MatineeFaceFXKeyAnimIDExistTitle", "Select Existing Animation ID"))
+					]
+				]
+			];
+
+		MenuBuilder.AddWidget(MenuEntry.ToSharedRef(), FText::GetEmpty(), true);
+
+		MenuBuilder.EndSection();
+
+		//fill existing animation ids
+		KeyframeAddFaceDXExistingAnimIds.Reset();
+		if(const UFaceFXCharacter* Character = FaceFXComponent->GetCharacter())
+		{
+			TArray<FFaceFXAnimId> ExistingAnimIds;
+			if(Character->GetAllLinkedAnimationIds(ExistingAnimIds))
+			{
+				for(const FFaceFXAnimId& AnimId : ExistingAnimIds)
+				{
+					KeyframeAddFaceDXExistingAnimIds.Add(MakeShareable(new FFaceFXAnimId(AnimId)));
+				}
+			}
+		}
+		AnimIdComboBox->RefreshOptions();
+
+#endif //FACEFX_USEANIMATIONLINKAGE
+
+		//Add animation specification by using the asset selection
+		MenuBuilder.BeginSection(NAME_None, LOCTEXT("MatineeFaceFXKeyAnimPicker", "Play By FaceFX Animation Asset"));
+		{
+			TSharedPtr<SBox> MenuEntry = SNew(SBox)
+			.WidthOverride(300.0f)
+			.HeightOverride(300.f)
+			[
+				ContentBrowserModule.Get().CreateAssetPicker(AssetPickerConfig)
+			];
+			MenuBuilder.AddWidget(MenuEntry.ToSharedRef(), FText::GetEmpty(), true);
+		}
+		MenuBuilder.EndSection();
+
+		EntryPopupWindow = FSlateApplication::Get().PushMenu(Parent.ToSharedRef(), MenuBuilder.MakeWidget(), FSlateApplication::Get().GetCursorPos(), FPopupTransitionEffect(FPopupTransitionEffect::TypeInPopup));
+	}
+
+	return false;
+}
+
+void UFaceFXMatineeControlHelper::OnAnimAssetSelected(const FAssetData& AssetData, IMatineeBase* Matinee, UInterpTrack* Track)
+{
+	if( EntryPopupWindow.IsValid() )
+	{
+		EntryPopupWindow.Pin()->RequestDestroyWindow();
+	}
+
+	if (UFaceFXAnim* SelectedAnim = Cast<UFaceFXAnim>(AssetData.GetAsset()))
+	{
+		KeyframeAddFaceFXAnim = SelectedAnim;
+		Matinee->FinishAddKey(Track, true);
+	}
+}
+
+void UFaceFXMatineeControlHelper::OnKeyframeLoopCheckboxChange(ECheckBoxState NewState)
+{
+	bKeyframeSettingsLoop = NewState == ECheckBoxState::Checked;
+}
+
+void UFaceFXMatineeControlHelper::OnSkelMeshComboBoxSelected(TSharedPtr<FFaceFXSkelMeshSelection> NewSelection, enum ESelectInfo::Type SelectInfo, class IMatineeBase* Matinee, UInterpTrack* Track)
+{
+	if(const FFaceFXSkelMeshSelection* Selection = NewSelection.Get())
+	{
+		KeyframeAddSkelMeshComponentId = Selection->Id;
+		SkelMeshComponentSelection->SetText(Selection->Text);
+	}
+}
+
+TSharedRef<SWidget> UFaceFXMatineeControlHelper::MakeWidgetFromSkelMeshSelection(TSharedPtr<struct FFaceFXSkelMeshSelection> InItem)
+{
+	FString Text;
+	if(const FFaceFXSkelMeshSelection* SkelMeshSelection = InItem.Get())
+	{
+		Text = SkelMeshSelection->Text;
+	}
+
+	return SNew(STextBlock).Text(FText::FromString(*Text));
+}
+
+#if FACEFX_USEANIMATIONLINKAGE
+
+void UFaceFXMatineeControlHelper::OnAnimGroupCommitted(const FText& Text, ETextCommit::Type Type, IMatineeBase* Matinee, UInterpTrack* Track)
+{
+	check(Matinee);
+
+	KeyframeAddFaceFXAnimId.Group = FName(*Text.ToString());
+	
+	//if any of the two (group & id) popup widgets commit their text, we assume the input is done
+	if(Type != ETextCommit::OnEnter)
+	{
+		return;
+	}
+
+	if( EntryPopupWindow.IsValid() )
+	{
+		EntryPopupWindow.Pin()->RequestDestroyWindow();
+	}
+
+	Matinee->FinishAddKey(Track, true);
+}
+
+void UFaceFXMatineeControlHelper::OnAnimIdCommitted(const FText& Text, ETextCommit::Type Type, IMatineeBase* Matinee, UInterpTrack* Track)
+{
+	check(Matinee);
+
+	KeyframeAddFaceFXAnimId.Name = FName(*Text.ToString());
+	
+	//if any of the two (group & id) popup widgets commit their text, we assume the input is done
+	if(Type != ETextCommit::OnEnter)
+	{
+		return;
+	}
+
+	if( EntryPopupWindow.IsValid() )
+	{
+		EntryPopupWindow.Pin()->RequestDestroyWindow();
+	}
+
+	Matinee->FinishAddKey(Track, true);
+}
+
+TSharedRef<SWidget> UFaceFXMatineeControlHelper::MakeWidgetFromAnimId(TSharedPtr<FFaceFXAnimId> InItem)
+{
+	FString Text;
+	if(FFaceFXAnimId* AnimId = InItem.Get())
+	{
+		Text = AnimId->Group.IsNone() ? TEXT("") : AnimId->Group.ToString() + TEXT(" / ");
+		Text += AnimId->Name.ToString();
+	}
+
+	return SNew(STextBlock).Text(FText::FromString(*Text));
+}
+
+void UFaceFXMatineeControlHelper::OnAnimIdComboBoxSelected(TSharedPtr<FFaceFXAnimId> NewSelection, enum ESelectInfo::Type SelectInfo, IMatineeBase* Matinee, UInterpTrack* Track)
+{
+	check(Matinee);
+
+	if( EntryPopupWindow.IsValid() )
+	{
+		EntryPopupWindow.Pin()->RequestDestroyWindow();
+	}
+
+	if(const FFaceFXAnimId* SelectedAnimId = NewSelection.Get())
+	{
+		KeyframeAddFaceFXAnimId = *SelectedAnimId;
+	}
+	else
+	{
+		KeyframeAddFaceFXAnimId.Reset();
+	}
+
+	Matinee->FinishAddKey(Track, true);
+};
+
+#endif //FACEFX_USEANIMATIONLINKAGE
+
+void UFaceFXMatineeControlHelper::PostCreateKeyframe( UInterpTrack *Track, int32 KeyIndex ) const
+{
+	UFaceFXMatineeControl* TrackFaceFX = CastChecked<UFaceFXMatineeControl>(Track);
+	FFaceFXTrackKey& NewAnimKey = TrackFaceFX->Keys[KeyIndex];
+	NewAnimKey.SkelMeshComponentId = KeyframeAddSkelMeshComponentId;
+	NewAnimKey.Animation = KeyframeAddFaceFXAnim;
+#if FACEFX_USEANIMATIONLINKAGE
+	NewAnimKey.AnimationId = KeyframeAddFaceFXAnimId;
+#endif //FACEFX_USEANIMATIONLINKAGE
+	NewAnimKey.bLoop = bKeyframeSettingsLoop;	
+
+	ResetCachedValues();
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/FaceFXEditor/Private/Matinee/FaceFXMatineeControlHelper.cpp
+++ b/Source/FaceFXEditor/Private/Matinee/FaceFXMatineeControlHelper.cpp
@@ -72,20 +72,23 @@ bool UFaceFXMatineeControlHelper::PreCreateTrack( UInterpGroup* Group, const UIn
 		if(!Actor->FindComponentByClass<UFaceFXComponent>())
 		{
 			UE_LOG(LogFaceFX, Warning, TEXT("InterpGroup : FaceFX component missing (%s)"), *Actor->GetName());
-
 			if(bAllowPrompts)
 			{
-				FNotificationInfo Info(LOCTEXT("MatineeFaceFXMissingComponent", "Unable to add FaceFX Track. Selected actor does not own a FaceFX Component."));
-				Info.ExpireDuration = 10.F;
-				Info.bUseLargeFont = false;
-				Info.Image = FEditorStyle::GetBrush(TEXT("MessageLog.Error"));
-				FSlateNotificationManager::Get().AddNotification(Info);
+				FFaceFXEditorTools::ShowError(LOCTEXT("MatineeFaceFXMissingComponent", "Unable to add FaceFX Track. Selected actor does not own a FaceFX Component."));
 			}
-
 			return false;
 		}
+		return true;
 	}
-	return true;
+	else
+	{
+		UE_LOG(LogFaceFX, Warning, TEXT("InterpGroup : Actor missing"));
+		if(bAllowPrompts)
+		{
+			FFaceFXEditorTools::ShowError(LOCTEXT("MatineeFaceFXMissingActor", "Unable to add FaceFX Track. No actor selected. Select an actor with a FaceFX component and try again."));
+		}
+	}
+	return false;
 }
 
 bool UFaceFXMatineeControlHelper::PreCreateKeyframe( UInterpTrack *Track, float fTime ) const

--- a/Source/FaceFXEditor/Private/Matinee/FaceFXMatineeControlHelper.cpp
+++ b/Source/FaceFXEditor/Private/Matinee/FaceFXMatineeControlHelper.cpp
@@ -66,6 +66,19 @@ bool UFaceFXMatineeControlHelper::PreCreateTrack( UInterpGroup* Group, const UIn
 	UInterpGroupInst* GrInst = InterpEd->GetMatineeActor()->FindFirstGroupInst(Group);
 	check(GrInst);
 
+	//check if the matinee actor already contains a facefx track
+	TArray<UInterpTrack*> Tracks;
+	Group->FindTracksByClass(UFaceFXMatineeControl::StaticClass(), Tracks);
+	if(Tracks.Num() > 0)
+	{
+		UE_LOG(LogFaceFX, Warning, TEXT("InterpGroup : Matinee group aready contains a FaceFX track (%s)"), *Group->GroupName.ToString());
+		if(bAllowPrompts)
+		{
+			FFaceFXEditorTools::ShowError(LOCTEXT("MatineeFaceFXAlreadyHasTrack", "Unable to add FaceFX Track. Target matinee group already contains a FaceFX track."));
+		}
+		return false;
+	}
+
 	if (AActor* Actor = GrInst->GetGroupActor())
 	{
 		//Locate FaceFX component

--- a/Source/FaceFXEditor/Public/FaceFXEditorTools.h
+++ b/Source/FaceFXEditor/Public/FaceFXEditorTools.h
@@ -605,6 +605,18 @@ struct FACEFXEDITOR_API FFaceFXEditorTools
 	*/
 	static void DeleteAsset(UObject* Asset);
 
+	/** 
+	* Shows a slate error message
+	* @param msg The error message to show
+	*/
+	static void ShowError(const FText& Msg);
+
+	/** 
+	* Shows a slate info message
+	* @param msg The info message to show
+	*/
+	static void ShowInfo(const FText& Msg);
+
 private:
 
 	FFaceFXEditorTools(){}


### PR DESCRIPTION
- Added FaceFX Matinee Track using key frames that can be assigned to specific skelmesh components in the owning actor
- Added support for specific audio component to be assigned when setting up the FaceFX component (for parallel audio playback of facial animation on different skelmesh components)
- Matinee keyframes support animation specification by id (existing or arbitrary) and by asset selection