### PR TITLE
Fix packaging failures

### DIFF
--- a/Documentation/Troubleshooting.md
+++ b/Documentation/Troubleshooting.md
@@ -1,6 +1,12 @@
 Troubleshooting
 ===============
 
+#### Errors when packaging
+
+There is a known bug in UE4 where it requires all plugin Build.cs files to be present when packaging a game. This effectively means that in order to package your game you need full source to the FaceFX plugin installed.
+
+If you are using the GitHub source, this is a non-issue. However, if you are using the Epic Launcher version of the engine, it means you need to get the full source to the FaceFX plugin, including the FaceFX Runtime library, and set it up in the Epic Launcher version of your engine. Place the source code in the same location you put the pre-built binaries of the FaceFX plugin (see the [README.md](README.md) file located in this repository).
+
 #### Audio plays with no animation and there are no FaceFX errors in the log
 
 Make sure the character's **Animation Blueprint** is referenced in the **Blueprint Class**, the **Blend FaceFX Animation** Blueprint node is added to the **Animation Blueprint**, and it is connected properly.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Supported Unreal Engine 4 versions
 
 The FaceFX UE4 plugin currently supports UE4 version 4.8.0 and up. It will not work unmodified on earlier versions of UE4.
 
+Documentation
+-------------
+
+The [FaceFX UE4 Plugin documentation](Documentation/Index.md) is located in the **Documentation** directory of this GitHub repository. Be sure to check out the [Troubleshooting](Documentation/Troubleshooting.md) section if you run into any problems.
+
+
 Installation
 ------------
 
@@ -98,11 +104,6 @@ First, make sure you are familiar with the process of cloning Unreal Engine from
 9. Load the UE4 project in Xcode. Select the **UE4Editor - Mac** for **My Mac** target in the title bar, then select the 'Product > Build' menu item.
 
 10. Run UnrealEd according to Epic's instructions.
-
-Documentation
--------------
-
-The [FaceFX UE4 Plugin documentation](Documentation/Index.md) is located in the **Documentation** directory of this GitHub repository.
 
 Contributing
 ------------

--- a/Source/FaceFX/FaceFX.Build.cs
+++ b/Source/FaceFX/FaceFX.Build.cs
@@ -29,7 +29,6 @@ public class FaceFX : ModuleRules
                 "Core",
                 "CoreUObject",
                 "Engine",
-                "TargetPlatform",
                 "FaceFXLib"
             }
         );

--- a/Source/FaceFXEditor/FaceFXEditor.Build.cs
+++ b/Source/FaceFXEditor/FaceFXEditor.Build.cs
@@ -38,7 +38,6 @@ public class FaceFXEditor : ModuleRules
                 "AssetRegistry",
                 "ContentBrowser",
                 "MainFrame",
-                "DesktopPlatform",
                 "AnimGraph",
                 "BlueprintGraph",
                 "FaceFX"


### PR DESCRIPTION
Remove references to TargetPlatform and DesktopPlatform to allow Rocket builds
to succeed.

Update documentation to mention the UE4 engine bug that source is required
during packaging, and update Troubleshooting documentation.

Finally, the documentation section in README.md was moved closer to the top of
the file.

Fixes #19