### PR TITLE
Initial support for morph targets driven by FaceFX tracks

### DIFF
--- a/Source/FaceFX/Classes/Animation/FaceFXComponent.h
+++ b/Source/FaceFX/Classes/Animation/FaceFXComponent.h
@@ -35,8 +35,8 @@ struct FACEFX_API FFaceFXEntry
 	GENERATED_USTRUCT_BODY()
 
 	FFaceFXEntry() : SkelMeshComp(nullptr), AudioComp(nullptr), Character(nullptr), bIsAutoPlaySound(true) {}
-	FFaceFXEntry(class USkeletalMeshComponent* InSkelMeshComp, class UAudioComponent* InAudioComp, const TAssetPtr<class UFaceFXActor>& InAsset, bool InIsAutoPlaySound = true) : 
-		SkelMeshComp(InSkelMeshComp), AudioComp(InAudioComp), Asset(InAsset), Character(nullptr), bIsAutoPlaySound(InIsAutoPlaySound) {}
+	FFaceFXEntry(class USkeletalMeshComponent* InSkelMeshComp, class UAudioComponent* InAudioComp, const TAssetPtr<class UFaceFXActor>& InAsset, bool InIsAutoPlaySound = true, bool InIsDisableMorphTargets = false) : 
+		SkelMeshComp(InSkelMeshComp), AudioComp(InAudioComp), Asset(InAsset), Character(nullptr), bIsAutoPlaySound(InIsAutoPlaySound), bIsDisableMorphTargets(InIsDisableMorphTargets) {}
 
 	/** The linked skelmesh component */
 	UPROPERTY(BlueprintReadOnly, Category=FaceFX)
@@ -47,12 +47,16 @@ struct FACEFX_API FFaceFXEntry
 	class UAudioComponent* AudioComp;
 
 	/** The asset to use when instantiating the facial character instance */
-	UPROPERTY(BlueprintReadOnly, EditAnywhere, Category=FaceFX, meta=(DisplayName="Asset"))
+	UPROPERTY(BlueprintReadOnly, EditAnywhere, Category=FaceFX)
 	TAssetPtr<class UFaceFXActor> Asset;
 
 	/** The FaceFX character instance that was created for this component */
-	UPROPERTY(Transient, BlueprintReadOnly, Category=FaceFX, meta=(DisplayName="Character"))
+	UPROPERTY(Transient, BlueprintReadOnly, Category=FaceFX)
 	class UFaceFXCharacter* Character;
+
+	/** Indicator if the morph targets are disabled */
+	UPROPERTY(BlueprintReadOnly, EditAnywhere, Category=FaceFX)
+	uint8 bIsDisableMorphTargets : 1;
 
 	/** Indicator that defines if the FaceFX character shall play the sound wave assigned to the FaceFX Animation asset automatically when this animation is getting played */
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category=FaceFX)
@@ -87,10 +91,11 @@ public:
 	* @param AudioComponent The audio component to assign to the FaceFX character. Keep empty to use the first audio component found on the owning actor.
 	* @param Asset The FaceFX asset to use
 	* @param IsAutoPlaySound Indicator that defines if the FaceFX character shall play the sound wave assigned to the FaceFX Animation asset automatically when this animation is getting played
+	* @param IsDisableMorphTargets Indicator if the use of available morph targets shall be disabled
 	* @return True if succeeded, else false
 	*/
 	UFUNCTION(BlueprintCallable, Category=FaceFX, Meta=(IsAutoPlaySound=true, HidePin="Caller", DefaultToSelf="Caller"))
-	bool Setup(USkeletalMeshComponent* SkelMeshComp, class UAudioComponent* AudioComponent, const UFaceFXActor* Asset, bool IsAutoPlaySound, const UObject* Caller = nullptr);
+	bool Setup(USkeletalMeshComponent* SkelMeshComp, class UAudioComponent* AudioComponent, const UFaceFXActor* Asset, bool IsAutoPlaySound, bool IsDisableMorphTargets, const UObject* Caller = nullptr);
 
 	/**
 	* Starts the playback of the given facial animation for a given skel mesh components character
@@ -205,7 +210,7 @@ public:
 	* @param SkelMeshComp The skelmesh component to get the character for. Keep empty to get the FaceFX character for the first skelmesh that was setup
 	* @returns The UFaceFXCharacter for the given skelmesh context
 	*/
-	inline UFaceFXCharacter* GetCharacter(USkeletalMeshComponent* SkelMeshComp = nullptr) const
+	inline UFaceFXCharacter* GetCharacter(const USkeletalMeshComponent* SkelMeshComp = nullptr) const
 	{
 		if(SkelMeshComp)
 		{
@@ -217,6 +222,23 @@ public:
 		}
 
 		return Entries.Num() > 0 ? Entries[0].Character : nullptr;
+	}
+
+	/**
+	* Gets the skel mesh component which owns a given FaceFX character instance
+	* @param FaceFXCharacter The FaceFX character instance to look up the skel mesh component for
+	* @returns The skel mesh component for the given FaceFX character or nullptr if not found
+	*/
+	inline USkeletalMeshComponent* GetSkelMeshTarget(const UFaceFXCharacter* FaceFXCharacter) const
+	{
+		if(FaceFXCharacter)
+		{
+			if(const FFaceFXEntry* Entry = Entries.FindByKey(FaceFXCharacter))
+			{
+				return Entry->SkelMeshComp;
+			}
+		}
+		return nullptr;
 	}
 
 	/** 

--- a/Source/FaceFX/Classes/FaceFXCharacter.h
+++ b/Source/FaceFX/Classes/FaceFXCharacter.h
@@ -125,9 +125,10 @@ public:
 	/**
 	* Loads the character data from the given data set
 	* @param Dataset The data set to load from
+	* @param IsDisabledMorphTargets Indicator if the use of available morph targets shall be disabled
 	* @returns True if succeeded, else false
 	*/
-	bool Load(const class UFaceFXActor* Dataset);
+	bool Load(const class UFaceFXActor* Dataset, bool IsDisabledMorphTargets);
 
 	/**
 	* Gets the indicator if this character have been loaded
@@ -351,6 +352,18 @@ private:
 	}
 
 	/** 
+	* Gets the skel mesh component that owns this FaceFX character
+	* @returns The owning skel mesh component or nullptr if not found
+	*/
+	class USkeletalMeshComponent* GetOwningSkelMeshComponent() const;
+
+	/** 
+	* Gets the FaceFX component that owns this FaceFX character instance
+	* @returns The FaceFX component or nullptr if there is no or another owner of this FaceFX character instance
+	*/
+	class UFaceFXComponent* GetOwningFaceFXComponent() const;
+
+	/** 
 	* Gets the owning actor
 	* @returns The actor or nullptr if not belonging to one
 	*/
@@ -457,6 +470,15 @@ private:
 	*/
 	bool TickUntil(float Duration, bool& OutAudioStarted);
 
+	/** 
+	* Retrieves the morph targets for a skel mesh and creates FaceFX indices for the names 
+	* @returns True if setup succeeded, else false
+	*/
+	bool SetupMorphTargets();
+
+	/** Processes the morph targets for the current frame state */
+	void ProcessMorphTargets();
+
 	/**
 	* Gets the latest internal facefx error message
 	* @returns The last error message
@@ -502,6 +524,12 @@ private:
 	/** The bone ids coming from the facefx asset */
 	TArray<uint64> BoneIds;
 
+	/** The list of morph target names retrieved from the skel mesh during asset loading. The indices match the morph target track values: MorphTargetTrackValues */
+	TArray<FName> MorphTargetNames;
+
+	/** The track values buffer for the morph target processing */
+	TArray<ffx_track_value_t> MorphTargetTrackValues;
+
 	/** The overall time progression */
 	float CurrentTime;
 
@@ -540,6 +568,9 @@ private:
 
 	/** Indicator that defines if the FaceFX character shall play the sound wave assigned to the FaceFX Animation asset automatically when this animation is getting played */
 	uint8 bIsAutoPlaySound : 1;
+
+	/** Indicator if the use of available morph targets shall be disabled */
+	uint8 bDisabledMorphTargets : 1;
 
 #if WITH_EDITOR
 	uint32 LastFrameNumber;

--- a/Source/FaceFX/Private/Animation/FaceFXComponent.cpp
+++ b/Source/FaceFX/Private/Animation/FaceFXComponent.cpp
@@ -33,7 +33,7 @@ void UFaceFXComponent::OnRegister()
 	CreateAllCharacters();
 }
 
-bool UFaceFXComponent::Setup(USkeletalMeshComponent* SkelMeshComp, UAudioComponent* AudioComponent, const UFaceFXActor* Asset, bool IsAutoPlaySound, const UObject* Caller)
+bool UFaceFXComponent::Setup(USkeletalMeshComponent* SkelMeshComp, UAudioComponent* AudioComponent, const UFaceFXActor* Asset, bool IsAutoPlaySound, bool IsDisableMorphTargets, const UObject* Caller)
 {
 	if(!SkelMeshComp)
 	{
@@ -51,7 +51,7 @@ bool UFaceFXComponent::Setup(USkeletalMeshComponent* SkelMeshComp, UAudioCompone
 	if(Idx == INDEX_NONE)
 	{
 		//add new entry
-		Idx = Entries.Add(FFaceFXEntry(SkelMeshComp, AudioComponent, Asset, IsAutoPlaySound));
+		Idx = Entries.Add(FFaceFXEntry(SkelMeshComp, AudioComponent, Asset, IsAutoPlaySound, IsDisableMorphTargets));
 	}
 	checkf(Idx != INDEX_NONE, TEXT("Internal Error: Unable to add new FaceFX entry."));
 
@@ -283,7 +283,7 @@ void UFaceFXComponent::CreateCharacter(FFaceFXEntry& Entry)
 			Entry.Character = NewObject<UFaceFXCharacter>(this);
 			checkf(Entry.Character, TEXT("Unable to instantiate a FaceFX character. Possibly Out of Memory."));
 
-			if(!Entry.Character->Load(FaceFXActor))
+			if(!Entry.Character->Load(FaceFXActor, Entry.bIsDisableMorphTargets))
 			{
 				UE_LOG(LogFaceFX, Error, TEXT("SkeletalMesh Component FaceFX failed to get initialized. Loading failed. Component=%s. Asset=%s"), *GetName(), *Entry.Asset.ToStringReference().ToString());
 				Entry.Character = nullptr;

--- a/Source/FaceFX/Private/Matinee/FaceFXMatineeControl.cpp
+++ b/Source/FaceFX/Private/Matinee/FaceFXMatineeControl.cpp
@@ -216,7 +216,10 @@ void UFaceFXMatineeControl::PreviewUpdateTrack( float NewPosition, UInterpTrackI
 		for(USkeletalMeshComponent* SkelMeshComp : SkelMeshComps)
 		{
 			// Update space bases so new animation position has an effect.
-			SkelMeshComp->UpdateMaterialParameters();
+			if(SkelMeshComp->AnimScriptInstance)
+			{
+				SkelMeshComp->UpdateMaterialParameters();
+			}
 			SkelMeshComp->RefreshBoneTransforms();
 			SkelMeshComp->RefreshSlaveComponents();
 			SkelMeshComp->UpdateComponentToWorld();


### PR DESCRIPTION
- FaceFX tracks must be names like morph targets
- Can be disabled via Setup node on the FaceFX component

Fixes #14