### PR TITLE
Initial support for morph targets driven by FaceFX tracks

### DIFF
--- a/Source/FaceFX/Classes/FaceFXCharacter.h
+++ b/Source/FaceFX/Classes/FaceFXCharacter.h
@@ -125,9 +125,10 @@ public:
 	/**
 	* Loads the character data from the given data set
 	* @param Dataset The data set to load from
+	* @param IsDisabledMorphTargets Indicator if the use of available morph targets shall be disabled
 	* @returns True if succeeded, else false
 	*/
-	bool Load(const class UFaceFXActor* Dataset);
+	bool Load(const class UFaceFXActor* Dataset, bool IsDisabledMorphTargets);
 
 	/**
 	* Gets the indicator if this character have been loaded
@@ -351,6 +352,18 @@ private:
 	}
 
 	/** 
+	* Gets the skel mesh component that owns this FaceFX character
+	* @returns The owning skel mesh component or nullptr if not found
+	*/
+	class USkeletalMeshComponent* GetOwningSkelMeshComponent() const;
+
+	/** 
+	* Gets the FaceFX component that owns this FaceFX character instance
+	* @returns The FaceFX component or nullptr if there is no or another owner of this FaceFX character instance
+	*/
+	class UFaceFXComponent* GetOwningFaceFXComponent() const;
+
+	/** 
 	* Gets the owning actor
 	* @returns The actor or nullptr if not belonging to one
 	*/
@@ -457,6 +470,15 @@ private:
 	*/
 	bool TickUntil(float Duration, bool& OutAudioStarted);
 
+	/** 
+	* Retrieves the morph targets for a skel mesh and creates FaceFX indices for the names 
+	* @returns True if setup succeeded, else false
+	*/
+	bool SetupMorphTargets();
+
+	/** Processes the morph targets for the current frame state */
+	void ProcessMorphTargets();
+
 	/**
 	* Gets the latest internal facefx error message
 	* @returns The last error message
@@ -502,6 +524,12 @@ private:
 	/** The bone ids coming from the facefx asset */
 	TArray<uint64> BoneIds;
 
+	/** The list of morph target names retrieved from the skel mesh during asset loading. The indices match the morph target track values: MorphTargetTrackValues */
+	TArray<FName> MorphTargetNames;
+
+	/** The track values buffer for the morph target processing */
+	TArray<ffx_track_value_t> MorphTargetTrackValues;
+
 	/** The overall time progression */
 	float CurrentTime;
 
@@ -540,6 +568,9 @@ private:
 
 	/** Indicator that defines if the FaceFX character shall play the sound wave assigned to the FaceFX Animation asset automatically when this animation is getting played */
 	uint8 bIsAutoPlaySound : 1;
+
+	/** Indicator if the use of available morph targets shall be disabled */
+	uint8 bDisabledMorphTargets : 1;
 
 #if WITH_EDITOR
 	uint32 LastFrameNumber;

--- a/Source/FaceFX/Private/Animation/FaceFXComponent.cpp
+++ b/Source/FaceFX/Private/Animation/FaceFXComponent.cpp
@@ -33,7 +33,7 @@ void UFaceFXComponent::OnRegister()
 	CreateAllCharacters();
 }
 
-bool UFaceFXComponent::Setup(USkeletalMeshComponent* SkelMeshComp, UAudioComponent* AudioComponent, const UFaceFXActor* Asset, bool IsAutoPlaySound, const UObject* Caller)
+bool UFaceFXComponent::Setup(USkeletalMeshComponent* SkelMeshComp, UAudioComponent* AudioComponent, const UFaceFXActor* Asset, bool IsAutoPlaySound, bool IsDisableMorphTargets, const UObject* Caller)
 {
 	if(!SkelMeshComp)
 	{
@@ -51,7 +51,7 @@ bool UFaceFXComponent::Setup(USkeletalMeshComponent* SkelMeshComp, UAudioCompone
 	if(Idx == INDEX_NONE)
 	{
 		//add new entry
-		Idx = Entries.Add(FFaceFXEntry(SkelMeshComp, AudioComponent, Asset, IsAutoPlaySound));
+		Idx = Entries.Add(FFaceFXEntry(SkelMeshComp, AudioComponent, Asset, IsAutoPlaySound, IsDisableMorphTargets));
 	}
 	checkf(Idx != INDEX_NONE, TEXT("Internal Error: Unable to add new FaceFX entry."));
 
@@ -283,7 +283,7 @@ void UFaceFXComponent::CreateCharacter(FFaceFXEntry& Entry)
 			Entry.Character = NewObject<UFaceFXCharacter>(this);
 			checkf(Entry.Character, TEXT("Unable to instantiate a FaceFX character. Possibly Out of Memory."));
 
-			if(!Entry.Character->Load(FaceFXActor))
+			if(!Entry.Character->Load(FaceFXActor, Entry.bIsDisableMorphTargets))
 			{
 				UE_LOG(LogFaceFX, Error, TEXT("SkeletalMesh Component FaceFX failed to get initialized. Loading failed. Component=%s. Asset=%s"), *GetName(), *Entry.Asset.ToStringReference().ToString());
 				Entry.Character = nullptr;

--- a/Source/FaceFX/Private/FaceFXCharacter.cpp
+++ b/Source/FaceFX/Private/FaceFXCharacter.cpp
@@ -57,7 +57,9 @@ UFaceFXCharacter::UFaceFXCharacter(const class FObjectInitializer& PCIP) : Super
 	AudioPlaybackState(EPlaybackState::Stopped),
 	bIsDirty(true),
 	bIsLooping(false),
-	bCanPlay(true)
+	bCanPlay(true),
+	bIsAutoPlaySound(false),
+	bDisabledMorphTargets(false)
 #if WITH_EDITOR
 	,LastFrameNumber(0)
 #endif
@@ -115,6 +117,8 @@ bool UFaceFXCharacter::TickUntil(float Duration, bool& OutAudioStarted)
 	CurrentAnimProgress = CurrentTime - CurrentAnimStart;
 	bIsDirty = true;
 
+	ProcessMorphTargets();
+	
 	return true;
 }
 
@@ -171,6 +175,8 @@ void UFaceFXCharacter::Tick(float DeltaTime)
 		
 		OnPlaybackStartAudio.Broadcast(this, CurrentAnim, AudioStarted, AudioCompStartedOn);					
 	}
+
+	ProcessMorphTargets();
 
 	bIsDirty = true;
 }
@@ -593,7 +599,10 @@ void UFaceFXCharacter::Reset()
 	XForms.Empty();
 	BoneTransforms.Empty();
 	BoneIds.Empty();
-	
+
+	MorphTargetNames.Empty();
+	MorphTargetTrackValues.Empty();
+
 	FaceFXActor = nullptr;
 
 	bIsDirty = true;
@@ -604,7 +613,7 @@ bool UFaceFXCharacter::IsPlayingOrPaused(const class UFaceFXAnim* Animation) con
 	return Animation && IsPlayingOrPaused(Animation->GetId());
 }
 
-bool UFaceFXCharacter::Load(const UFaceFXActor* Dataset)
+bool UFaceFXCharacter::Load(const UFaceFXActor* Dataset, bool IsDisabledMorphTargets)
 {
 	SCOPE_CYCLE_COUNTER(STAT_FaceFXLoad);
 
@@ -706,6 +715,126 @@ bool UFaceFXCharacter::Load(const UFaceFXActor* Dataset)
 	    }
     }
 
+	bDisabledMorphTargets = IsDisabledMorphTargets;
+	if(!bDisabledMorphTargets && !SetupMorphTargets())
+	{
+		Reset();
+		return false;
+	}
+
+	return true;
+}
+
+void UFaceFXCharacter::ProcessMorphTargets()
+{
+	checkf(MorphTargetNames.Num() == MorphTargetTrackValues.Num(), TEXT("Morph target names indices must match the track values buffer"));
+
+	const int32 MorphTargetsToProcess = MorphTargetTrackValues.Num();
+	if(MorphTargetsToProcess == 0)
+	{
+		//no morph target to process
+		return;
+	}
+
+	//read track values
+	if(!Check(ffx_read_frame_track_values(FrameState, &MorphTargetTrackValues[0], MorphTargetsToProcess)))
+	{
+		UE_LOG(LogFaceFX, Error, TEXT("UFaceFXCharacter::ProcessMorphTargets. Unable to process morph targets. %s. Asset: %s"), *GetFaceFXError(), *GetNameSafe(FaceFXActor));
+		return;
+	}
+
+	//apply morph target track values
+	if(USkeletalMeshComponent* SkelMeshComp = GetOwningSkelMeshComponent())
+	{
+		for(int32 Idx = 0; Idx < MorphTargetsToProcess; ++Idx)
+		{
+			SkelMeshComp->SetMorphTarget(MorphTargetNames[Idx], MorphTargetTrackValues[Idx].value);
+		}
+	}
+	else
+	{
+		UE_LOG(LogFaceFX, Error, TEXT("UFaceFXCharacter::ProcessMorphTargets. Unable to find owners skel mesh component. Actor: %s. Asset: %s"), *GetNameSafe(GetOwningActor()), *GetNameSafe(FaceFXActor));
+		return;
+	}
+}
+
+bool UFaceFXCharacter::SetupMorphTargets()
+{
+	check(IsLoaded());
+
+	//reset morph target data
+	MorphTargetNames.Reset();
+	MorphTargetTrackValues.Reset();
+
+	if(USkeletalMeshComponent* SkelMeshComp = GetOwningSkelMeshComponent())
+	{
+		const int32 NumMorphTargets = SkelMeshComp->SkeletalMesh ? SkelMeshComp->SkeletalMesh->MorphTargetIndexMap.Num() : 0;
+		if(NumMorphTargets == 0)
+		{
+			//no morph targets in skel mesh
+			return true;
+		}
+		
+		//the lookup for the created facefx ids and the morph target names
+		TMap<uint64_t, FName> NameLookUp;
+		NameLookUp.Reserve(NumMorphTargets);
+
+		TArray<ffx_id_index_t> TrackIndices;
+		TrackIndices.Reserve(NumMorphTargets);
+
+		for(auto It = SkelMeshComp->SkeletalMesh->MorphTargetIndexMap.CreateConstIterator(); It; ++It)
+		{
+			const FName& MorphTarget = It.Key();
+
+			ffx_id_index_t IdIndex;
+			if(!Check(ffx_create_id(TCHAR_TO_ANSI(*MorphTarget.ToString()), &IdIndex.id)))
+			{
+				UE_LOG(LogFaceFX, Error, TEXT("UFaceFXCharacter::SetupMorphTargets. Unable to create FaceFX id for FaceFX track <%s>. %s. Asset: %s"), *MorphTarget.ToString(), *GetFaceFXError(), *GetNameSafe(FaceFXActor));
+				return false;
+			}
+
+			TrackIndices.Add(IdIndex);
+			NameLookUp.Add(IdIndex.id, MorphTarget);
+		}
+
+		//fetch the track indices by their facefx ids generated for the morph target names
+		if(!Check(ffx_find_tracks_in_actor_by_id(ActorHandle, &TrackIndices[0], NumMorphTargets)))
+		{
+			UE_LOG(LogFaceFX, Error, TEXT("UFaceFXCharacter::SetupMorphTargets. Unable to fetch FaceFX track indices. %s. Asset: %s"), *GetFaceFXError(), *GetNameSafe(FaceFXActor));
+			return false;
+		}
+
+		//sort by track indices for FaceFX runtime performance reasons
+		TrackIndices.Sort([](const ffx_id_index_t& A, const ffx_id_index_t& B) 
+		{
+			return A.index < B.index;
+		});
+
+		//map back track indices with morph target names
+		for(const ffx_id_index_t& TrackIndex : TrackIndices)
+		{
+			//lookup name to map track index back to the originating morph target
+			const FName& MorphTarget = NameLookUp.FindChecked(TrackIndex.id);
+
+			if(TrackIndex.index == INDEX_NONE)
+			{
+				//Track was not found -> ignore morph target
+				UE_LOG(LogFaceFX, Verbose, TEXT("UFaceFXCharacter::SetupMorphTargets. No FaceFX track found for SkelMesh Morph Target <%s>. SkelMesh: &s. Asset: %s"), 
+					*MorphTarget.ToString(), *GetNameSafe(SkelMeshComp->SkeletalMesh), *GetNameSafe(FaceFXActor));
+				continue;
+			}
+
+			//store the morph target names
+			MorphTargetNames.Add(MorphTarget);
+
+			//prepare the track value buffer
+			ffx_track_value_t NewTrackValue;
+			NewTrackValue.index = TrackIndex.index;
+			MorphTargetTrackValues.Add(NewTrackValue);
+		}
+	}
+	
+	checkf(MorphTargetNames.Num() == MorphTargetTrackValues.Num(), TEXT("Morph target names indices must match the track values buffer"));
 	return true;
 }
 
@@ -774,6 +903,17 @@ ffx_anim_handle_t* UFaceFXCharacter::LoadAnimation(const FFaceFXAnimData& AnimDa
 	}
 	
 	return NewHandle;
+}
+
+USkeletalMeshComponent* UFaceFXCharacter::GetOwningSkelMeshComponent() const
+{
+	const UFaceFXComponent* FaceFXComp = GetOwningFaceFXComponent();
+	return FaceFXComp ? FaceFXComp->GetSkelMeshTarget(this) : nullptr;
+}
+
+UFaceFXComponent* UFaceFXCharacter::GetOwningFaceFXComponent() const
+{
+	return Cast<UFaceFXComponent>(GetOuter());
 }
 
 AActor* UFaceFXCharacter::GetOwningActor() const
@@ -971,7 +1111,7 @@ void UFaceFXCharacter::OnFaceFXAssetChanged(UFaceFXAsset* Asset)
 		if(UFaceFXActor* ActorAsset = Cast<UFaceFXActor>(Asset))
 		{
 			//actor asset changed -> reload whole actor
-			Load(ActorAsset);
+			Load(ActorAsset, bDisabledMorphTargets);
 		}
 		else
 		{

--- a/Source/FaceFX/Private/Matinee/FaceFXMatineeControl.cpp
+++ b/Source/FaceFX/Private/Matinee/FaceFXMatineeControl.cpp
@@ -216,7 +216,10 @@ void UFaceFXMatineeControl::PreviewUpdateTrack( float NewPosition, UInterpTrackI
 		for(USkeletalMeshComponent* SkelMeshComp : SkelMeshComps)
 		{
 			// Update space bases so new animation position has an effect.
-			SkelMeshComp->UpdateMaterialParameters();
+			if(SkelMeshComp->AnimScriptInstance)
+			{
+				SkelMeshComp->UpdateMaterialParameters();
+			}
 			SkelMeshComp->RefreshBoneTransforms();
 			SkelMeshComp->RefreshSlaveComponents();
 			SkelMeshComp->UpdateComponentToWorld();


### PR DESCRIPTION
- FaceFX tracks must be names like morph targets
- Can be disabled via Setup node on the FaceFX component

Fixes #14