### PR TITLE
Update plugin version & doc engine version refs

### DIFF
--- a/Documentation/RequirementsAndKeyConcepts.md
+++ b/Documentation/RequirementsAndKeyConcepts.md
@@ -10,7 +10,7 @@ Requirements
 
 + The FaceFX Runtime plugin for FaceFX Studio, which is available as part of the [FaceFX Runtime distribution](https://www.facefx.com/runtime-downloads), is required to process content prior to being imported into Unreal Engine 4.
 
-+ [Unreal Engine 4](https://www.unrealengine.com) version 4.8 or later.
++ [Unreal Engine 4](https://www.unrealengine.com) version 4.9 or later.
 
 + The FaceFX UE4 Plugin, which is available in a [pre-compiled binary distribution](https://unreal.facefx.com) or in [source code](https://www.github.com/FaceFX/FaceFX-UE4) form.
 

--- a/FaceFX.uplugin
+++ b/FaceFX.uplugin
@@ -3,11 +3,11 @@
 
 	"FriendlyName" : "FaceFX",
 	"Version" : 1,
-	"VersionName" : "0.9.0",
+	"VersionName" : "0.9.1",
 	"CreatedBy" : "OC3 Entertainment, Inc.",
 	"CreatedByURL" : "http://www.facefx.com/",
     "DocsURL" : "http://unreal.facefx.com/",
-	"EngineVersion" : "4.8.0",
+	"EngineVersion" : "4.9.0",
 	"Description" : "Enables engine and editor support for facial animations powered by FaceFX.",
 	"Category" : "FaceFX",
 	"EnabledByDefault" : true,

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Complete licensing information can be found in the [LICENSE.md](LICENSE.md) file
 Supported Unreal Engine 4 versions
 ----------------------------------
 
-The FaceFX UE4 plugin currently supports UE4 version 4.8.0 and up. It will not work unmodified on earlier versions of UE4.
+The latest FaceFX UE4 plugin currently supports UE4 version 4.9.0 and up. It will not work unmodified on earlier versions of UE4.
 
 Documentation
 -------------
@@ -38,13 +38,13 @@ The following steps describe how to install the FaceFX UE4 plugin:
 
 #### Pre-built binaries
 
-**Note**: The pre-built binaries distribution will only work with the version of UE4 that is installed from inside the Epic Games Launcher application (currently 4.8.1). If you are using the UE4 GitHub source code you need to follow the directions for building the plugin from source.
+**Note**: The pre-built binaries distribution will only work with the version of UE4 that is installed from inside the Epic Games Launcher application (currently 4.9.0). If you are using the UE4 GitHub source code you need to follow the directions for building the plugin from source.
 
 ##### Windows
 
 1. [Download](https://unreal.facefx.com) the pre-built binaries distribution.
 
-2. Unzip the pre-built binaries distribution into your **C:\Program Files\Epic Games\4.8\Engine\Plugins\Runtime** directory. You should now have this directory: **C:\Program Files\Epic Games\4.8\Engine\Plugins\Runtime\FaceFX**.
+2. Unzip the pre-built binaries distribution into your **C:\Program Files\Epic Games\4.9\Engine\Plugins\Runtime** directory. You should now have this directory: **C:\Program Files\Epic Games\4.9\Engine\Plugins\Runtime\FaceFX**.
 
 3. Run UE4 from the Epic Games Launcher.
 
@@ -52,7 +52,7 @@ The following steps describe how to install the FaceFX UE4 plugin:
 
 1. [Download](https://unreal.facefx.com) the pre-built binaries distribution.
 
-2. Unzip the pre-built binaries distribution into your **/Users/Shared/UnrealEngine/4.8/Engine/Plugins/Runtime** directory. You should now have this directory: **/Users/Shared/UnrealEngine/4.8/Engine/Plugins/Runtime/FaceFX**.
+2. Unzip the pre-built binaries distribution into your **/Users/Shared/UnrealEngine/4.9/Engine/Plugins/Runtime** directory. You should now have this directory: **/Users/Shared/UnrealEngine/4.9/Engine/Plugins/Runtime/FaceFX**.
 
 3. Run UE4 from the Epic Games Launcher.
 


### PR DESCRIPTION
Bumped the plugin to 0.9.1 and changed the Unreal Engine version references in
the documentation to 4.9.

Fixes #35