### PR TITLE
Fixing some editor sequencer playback issues.

### DIFF
--- a/Source/FaceFX/Classes/FaceFXCharacter.h
+++ b/Source/FaceFX/Classes/FaceFXCharacter.h
@@ -100,9 +100,10 @@ public:
 
 	/**
 	* Stops the playback of this facial animation
+	* @param enforceStop Indicator if the stop is enforced no matter of current state
 	* @returns True if succeeded, else false
 	*/
-	bool Stop();
+	bool Stop(bool enforceStop = false);
 
 	/**
 	* Restarts the current animation
@@ -458,9 +459,10 @@ private:
 
 	/** 
 	* Stops the playback of the currently playing audio
+	* @param enforceAudioCompStop Indicator if the stop on the audio component is enforced
 	* @returns True if succeeded, else false
 	*/
-	bool StopAudio();
+	bool StopAudio(bool enforceAudioCompStop = false);
 
 	/** 
 	* Resumes the playback of the currently paused audio

--- a/Source/FaceFX/Classes/Sequencer/FaceFXAnimationSection.h
+++ b/Source/FaceFX/Classes/Sequencer/FaceFXAnimationSection.h
@@ -131,12 +131,12 @@ public:
 	}
 
 	//UMovieSceneSection
+	virtual void TrimSection(float TrimTime, bool bTrimLeft) override;
 	virtual UMovieSceneSection* SplitSection(float SplitTime) override;
 	virtual void GetKeyHandles(TSet<FKeyHandle>& OutKeyHandles, TRange<float> TimeRange) const override { }
 	virtual void GetSnapTimes(TArray<float>& OutSnapTimes, bool bGetSectionBorders) const override;
 	virtual TOptional<float> GetKeyTime(FKeyHandle KeyHandle) const override { return TOptional<float>(); }
-  // Note: jcr -- renamed Time to Time_ so as not to shadow private Time member.
-	virtual void SetKeyTime(FKeyHandle KeyHandle, float Time_) override { }
+	virtual void SetKeyTime(FKeyHandle KeyHandle, float KeyTime) override { }
 	//~UMovieSceneSection
 
 private:

--- a/Source/FaceFX/Private/FaceFXCharacter.cpp
+++ b/Source/FaceFX/Private/FaceFXCharacter.cpp
@@ -479,9 +479,9 @@ bool UFaceFXCharacter::Pause(bool fadeOut)
 	return true;
 }
 
-bool UFaceFXCharacter::Stop()
+bool UFaceFXCharacter::Stop(bool enforceStop)
 {
-	if(!IsLoaded())
+	if (!IsLoaded() && !enforceStop)
 	{
 		//not loaded yet
 		return false;
@@ -506,7 +506,7 @@ bool UFaceFXCharacter::Stop()
 	CurrentAnimProgress = .0F;
 	CurrentAnim.Reset();
 	AnimPlaybackState = EPlaybackState::Stopped;
-	StopAudio();
+	StopAudio(enforceStop);
 
 	UnloadCurrentAnim();
 
@@ -572,13 +572,10 @@ bool UFaceFXCharacter::JumpTo(float Position)
 	{
 		const float AudioPosition = Position + CurrentAnimStart;
 		checkf(AudioPosition >= 0.F, TEXT("Invalid audio playback range."));
-		PlayAudio(AudioPosition);
-	}
-	else
-	{
-		StopAudio();
+		return PlayAudio(AudioPosition);
 	}
 
+	StopAudio();
 	return true;
 }
 
@@ -984,6 +981,7 @@ bool UFaceFXCharacter::PlayAudio(float Position, UAudioComponent** OutAudioComp)
 		{
 			CurrentAudioProgress = FMath::Clamp(Position, 0.F, Sound->GetDuration());
 			AudioComp->SetSound(Sound);
+			AudioComp->bIsUISound = true;
 			AudioComp->Play(CurrentAudioProgress);
 
 			if(OutAudioComp)
@@ -1034,9 +1032,9 @@ bool UFaceFXCharacter::PauseAudio(bool fadeOut)
 	return false;
 }
 
-bool UFaceFXCharacter::StopAudio()
+bool UFaceFXCharacter::StopAudio(bool enforceAudioCompStop)
 {
-	if(!IsPlayingOrPausedAudio())
+	if (!IsPlayingOrPausedAudio() && !enforceAudioCompStop)
 	{
 		//nothing playing right now
 		return true;

--- a/Source/FaceFX/Private/Sequencer/FaceFXAnimationSection.cpp
+++ b/Source/FaceFX/Private/Sequencer/FaceFXAnimationSection.cpp
@@ -39,6 +39,26 @@ UFaceFXAnimationSection::UFaceFXAnimationSection(const FObjectInitializer& Objec
 	AnimationDuration = 0.F;
 }
 
+void UFaceFXAnimationSection::TrimSection(float TrimTime, bool bTrimLeft)
+{
+	if (IsTimeWithinSection(TrimTime))
+	{
+		SetFlags(RF_Transactional);
+		if (TryModify())
+		{
+			if (bTrimLeft)
+			{
+				StartOffset = TrimTime - GetStartTime();
+				SetStartTime(TrimTime);
+			}
+			else
+			{
+				SetEndTime(TrimTime);
+			}
+		}
+	}
+}
+
 UMovieSceneSection* UFaceFXAnimationSection::SplitSection(float SplitTime)
 {
 	const float AnimPosition = SplitTime - GetStartTime();

--- a/Source/FaceFX/Private/Sequencer/FaceFXAnimationTrack.cpp
+++ b/Source/FaceFX/Private/Sequencer/FaceFXAnimationTrack.cpp
@@ -49,7 +49,7 @@ UMovieSceneSection* UFaceFXAnimationTrack::GetSectionAtTime(float Time) const
 {
 	for (UMovieSceneSection* Section : AnimationSections)
 	{
-		if (Section->IsTimeWithinSection(Time))
+		if (Section->IsActive() && Section->IsTimeWithinSection(Time))
 		{
 			return Section;
 		}

--- a/Source/FaceFXEditor/Private/Sequencer/FaceFXAnimationTrackEditor.cpp
+++ b/Source/FaceFXEditor/Private/Sequencer/FaceFXAnimationTrackEditor.cpp
@@ -129,11 +129,17 @@ void FFaceFXAnimationTrackEditor::OnFaceFXTrackDialogClosed(FGuid ObjectBinding)
 
 void FFaceFXAnimationTrackEditor::BuildObjectBindingTrackMenu(FMenuBuilder& MenuBuilder, const FGuid& ObjectBinding, const UClass* ObjectClass)
 {
+	if (ObjectClass != UFaceFXComponent::StaticClass())
+	{
+		//only show widget on the component menu
+		return;
+	}
+
 	if (UFaceFXComponent* FaceFXComponent = GetFaceFXComponent(ObjectBinding))
 	{
 		MenuBuilder.AddMenuEntry(
-			LOCTEXT("SequencerAddSection", "FaceFX"),
-			LOCTEXT("SequencerAddSectionTooltip", "Adds a FaceFX section"),
+			LOCTEXT("SequencerAddSection", "Facial Animation"),
+			LOCTEXT("SequencerAddSectionTooltip", "Adds a FaceFX facial animation section"),
 			FSlateIcon(),
 			FUIAction(FExecuteAction::CreateRaw(this, &FFaceFXAnimationTrackEditor::OnAddKey, ObjectBinding)));
 	}
@@ -193,9 +199,9 @@ TSharedPtr<SWidget> FFaceFXAnimationTrackEditor::BuildOutlinerEditWidget(const F
 	{
 		//only create widgets for valid bindings
 
-		TSharedRef<SWidget> FaceFXAddTrackButton = FSequencerUtilities::MakeAddButton(LOCTEXT("SequencerAddSection", "FaceFX"),
+		TSharedRef<SWidget> FaceFXAddTrackButton = FSequencerUtilities::MakeAddButton(LOCTEXT("SequencerAddSection", "Facial Animation"),
 			FOnGetContent::CreateSP(this, &FFaceFXAnimationTrackEditor::CreateOutlinerWidget, ObjectBinding), Params.NodeIsHovered);
-		FaceFXAddTrackButton->SetToolTipText(LOCTEXT("SequencerAddSectionTooltip", "Adds a FaceFX section"));
+		FaceFXAddTrackButton->SetToolTipText(LOCTEXT("SequencerAddSectionTooltip", "Adds a FaceFX facial animation section"));
 
 		return SNew(SHorizontalBox)
 			+ SHorizontalBox::Slot()


### PR DESCRIPTION
- Fix for audio playback issue when ending PIE (world is not allowed to play audio during one frame)
- Fixing scrubbing issues in seqencer
- Stopping all playback when ending PIE or saving a world
- Removal of Sequencer Add Track button. Relying on component now