### PR TITLE
Fix for #87: Error when using -cookonthefly for Xbox One

### DIFF
--- a/Source/FaceFX/Classes/FaceFXAnim.h
+++ b/Source/FaceFX/Classes/FaceFXAnim.h
@@ -284,7 +284,7 @@ public:
 private:
 
 	/** The animation data. Its a list of data per platform. Will be cooked out to only the target platform. */
-	UPROPERTY(EditInstanceOnly, Category=FaceFX)
+	UPROPERTY(VisibleInstanceOnly, Category=FaceFX)
 	TArray<FFaceFXAnimData> PlatformData;
 
 	/** The animation Id */

--- a/Source/FaceFX/Classes/FaceFXAsset.h
+++ b/Source/FaceFX/Classes/FaceFXAsset.h
@@ -134,10 +134,48 @@ protected:
 	/**
 	* Clear platform specific data based on the target Archive platform
 	* @param Ar The archive to use
-	* @param platformData The data to clear
+	* @param PlatformData The data to clear
 	* @returns True if succeeded, else false
 	*/
-	template <typename T> bool ClearPlatformData(const class FArchive& Ar, T& platformData);
+	template <typename T> bool ClearPlatformData(const class FArchive& Ar, T& PlatformData);
+
+	/** 
+	* Clears the platform data for cooking assets and restores them after the cook is done. 
+	* Ensures the runtime asset contains all the data after cooking
+	*/
+	template <typename T> struct FScopedPlatformDataCooking
+	{
+		FScopedPlatformDataCooking(UFaceFXAsset* InAsset, const FArchive& Ar, T* InPlatformData) : PlatformData(InPlatformData)
+		{
+			bClearAndRestore = !InAsset->IsTemplate() && Ar.IsSaving() && Ar.IsCooking();
+			if (bClearAndRestore)
+			{
+				//create a copy and clear for later restoration
+				OriginalPlatformData = *PlatformData;
+				InAsset->ClearPlatformData(Ar, *PlatformData);
+			}
+		}
+
+		~FScopedPlatformDataCooking()
+		{
+			if (bClearAndRestore)
+			{
+				//restore platform data
+				*PlatformData = OriginalPlatformData;
+			}
+		}
+
+	private:
+
+		/** The original platform data */
+		T OriginalPlatformData;
+
+		/** The target platform data to operate on */
+		T* PlatformData;
+
+		/** Indicator if platform data got cleared and shall be restored when leaving the scope */
+		bool bClearAndRestore;
+	};
 
 #endif //WITH_EDITORONLY_DATA
 };

--- a/Source/FaceFX/Classes/FaceFXData.h
+++ b/Source/FaceFX/Classes/FaceFXData.h
@@ -40,19 +40,45 @@ namespace EFaceFXTargetPlatform
 	enum Type
 	{
 		PC = 0,
-#if FACEFX_SUPPORT_PS4
 		PS4,
-#endif
-#if FACEFX_SUPPORT_XBONE
 		XBoxOne,
-#endif
-		MAX
+		MAX UMETA(Hidden)
 	};
 }
 
 /** Helper stuff for the enum EFaceFXTargetPlatform */
 namespace EFaceFXTargetPlatformHelper
 {
+	/** 
+	* Gets the indicator if the given platform type is supported by the plugin build. 
+	* Controlled via FaceFXConfig.h preprocessor defines (FACEFX_SUPPORT_PS4, FACEFX_SUPPORT_XBONE)
+	* @param Platform The platform type to check
+	* @returns True if supported, else false
+	*/
+	static inline bool IsSupported(EFaceFXTargetPlatform::Type Platform)
+	{
+		switch (Platform)
+		{
+		case EFaceFXTargetPlatform::PC:
+		{
+			return true;
+		}
+#if FACEFX_SUPPORT_PS4
+		case EFaceFXTargetPlatform::PS4:
+		{
+			return true;
+		}
+#endif //FACEFX_SUPPORT_PS4
+#if FACEFX_SUPPORT_XBONE
+		case EFaceFXTargetPlatform::XBoxOne:
+		{
+			return true;
+		}
+#endif //FACEFX_SUPPORT_XBONE
+		}
+		return false;
+	}
+
 	/**
 	* Converts the given platform type to a string representation
 	* @param Platform The platform type
@@ -67,20 +93,16 @@ namespace EFaceFXTargetPlatformHelper
 				static FString s_PC = TEXT("PC");
 				return s_PC;
 			}
-#if FACEFX_SUPPORT_PS4
 		case EFaceFXTargetPlatform::PS4:
 			{
 				static FString s_PS4 = TEXT("PS4");
 				return s_PS4;
 			}
-#endif
-#if FACEFX_SUPPORT_XBONE
 		case EFaceFXTargetPlatform::XBoxOne:
 			{
 				static FString s_XBONE = TEXT("XBONE");
 				return s_XBONE;
 			}
-#endif
 		}
 
 		static FString s_UNKNOWN = TEXT("<Unknown>");

--- a/Source/FaceFX/Private/Audio/FaceFXAudioImplDefault.h
+++ b/Source/FaceFX/Private/Audio/FaceFXAudioImplDefault.h
@@ -27,7 +27,7 @@ class UAudioComponent;
 /** Audio layer that uses the Unreal Audio System */
 struct FFaceFXAudioDefault : public IFaceFXAudio, public FGCObject
 {
-	FFaceFXAudioDefault(UFaceFXCharacter* InOwner) : AudioComponent(nullptr), IFaceFXAudio(InOwner) {}
+	FFaceFXAudioDefault(UFaceFXCharacter* InOwner) : IFaceFXAudio(InOwner), AudioComponent(nullptr) {}
 
 	/**
 	* Prepares the audio data if needed for the current animation

--- a/Source/FaceFX/Private/FaceFXActor.cpp
+++ b/Source/FaceFX/Private/FaceFXActor.cpp
@@ -61,13 +61,10 @@ void UFaceFXActor::GetResourceSizeEx(FResourceSizeEx& CumulativeResourceSize)
 
 void UFaceFXActor::Serialize(FArchive& Ar)
 {
+	FScopedPlatformDataCooking<TArray<FFaceFXActorData>> ScopedCooking(this, Ar, &PlatformData);
+
 	if(!IsTemplate() && Ar.IsSaving())
 	{
-		if(Ar.IsCooking())
-		{
-			ClearPlatformData(Ar, PlatformData);
-		}
-
 #if FACEFX_USEANIMATIONLINKAGE
 		//cleanup references to deleted assets
 		for(int32 i=Animations.Num()-1; i>=0; --i)

--- a/Source/FaceFX/Private/FaceFXAnim.cpp
+++ b/Source/FaceFX/Private/FaceFXAnim.cpp
@@ -57,11 +57,7 @@ void UFaceFXAnim::GetResourceSizeEx(FResourceSizeEx& CumulativeResourceSize)
 
 void UFaceFXAnim::Serialize(FArchive& Ar)
 {
-	if(!IsTemplate() && Ar.IsSaving() && Ar.IsCooking())
-	{
-		ClearPlatformData(Ar, PlatformData);
-	}
-
+	FScopedPlatformDataCooking<TArray<FFaceFXAnimData>> ScopedCooking(this, Ar, &PlatformData);
 	Super::Serialize(Ar);
 }
 

--- a/Source/FaceFX/Private/FaceFXCharacter.cpp
+++ b/Source/FaceFX/Private/FaceFXCharacter.cpp
@@ -795,7 +795,7 @@ bool UFaceFXCharacter::SetupMorphTargets()
 		}
 
 		//the lookup for the created facefx ids and the morph target names
-		TMap<uint64_t, FName> NameLookUp;
+		TMap<uint64, FName> NameLookUp;
 		NameLookUp.Reserve(NumMorphTargets);
 
 		TArray<ffx_id_index_t> TrackIndices;

--- a/Source/FaceFXEditor/Private/FaceFXEditorTools.cpp
+++ b/Source/FaceFXEditor/Private/FaceFXEditorTools.cpp
@@ -415,6 +415,11 @@ bool FFaceFXEditorTools::LoadCompiledPlatformActorData(UFaceFXActor* Asset, cons
     for(int8 i = 0; i<EFaceFXTargetPlatform::MAX; ++i)
     {
         const EFaceFXTargetPlatform::Type Target = EFaceFXTargetPlatform::Type(i);
+		if (!EFaceFXTargetPlatformHelper::IsSupported(Target))
+		{
+			//unsupported target type - ignore
+			continue;
+		}
 
         const FString PlatformFolder = GetPlatformFolder(Folder, Target);
 
@@ -458,6 +463,11 @@ bool FFaceFXEditorTools::LoadCompiledPlatformActorData(UFaceFXActor* Asset, cons
     for(int8 i = 0; i<EFaceFXTargetPlatform::MAX; ++i)
     {
         const EFaceFXTargetPlatform::Type Target = EFaceFXTargetPlatform::Type(i);
+		if (!EFaceFXTargetPlatformHelper::IsSupported(Target))
+		{
+			//unsupported target type - ignore
+			continue;
+		}
 
         FFaceFXActorData& TargetData = Asset->GetOrCreatePlatformData(Target);
 
@@ -469,6 +479,11 @@ bool FFaceFXEditorTools::LoadCompiledPlatformActorData(UFaceFXActor* Asset, cons
     for(int8 i = 0; i<EFaceFXTargetPlatform::MAX; ++i)
     {
         const EFaceFXTargetPlatform::Type Target = EFaceFXTargetPlatform::Type(i);
+		if (!EFaceFXTargetPlatformHelper::IsSupported(Target))
+		{
+			//unsupported target type - ignore
+			continue;
+		}
 
         const FString PlatformFolder = GetPlatformFolder(Folder, Target);
 
@@ -837,6 +852,11 @@ bool FFaceFXEditorTools::LoadFromCompilationFolder(UFaceFXAnim* Asset, const FSt
 	for(int8 i=0; i<EFaceFXTargetPlatform::MAX; ++i)
 	{
 		const EFaceFXTargetPlatform::Type Target = EFaceFXTargetPlatform::Type(i);
+		if (!EFaceFXTargetPlatformHelper::IsSupported(Target))
+		{
+			//unsupported target type - ignore
+			continue;
+		}
 
 		const FString File = GetAnimAssetFileName(Folder, Asset->GetGroup().ToString(), Asset->GetName().ToString(), Target);
 		const bool FileExists = FPaths::FileExists(File);

--- a/Source/FaceFXEditor/Public/FaceFXEditorTools.h
+++ b/Source/FaceFXEditor/Public/FaceFXEditorTools.h
@@ -459,15 +459,13 @@ struct FACEFXEDITOR_API FFaceFXEditorTools
 	*/
 	static inline FString GetPlatformFolder(const FString& Folder, EFaceFXTargetPlatform::Type Platform)
 	{
+		checkf(EFaceFXTargetPlatformHelper::IsSupported(Platform), TEXT("Unsupported target platform type"));
+
 		switch(Platform)
 		{
 		case EFaceFXTargetPlatform::PC: return Folder / TEXT("x86");
-#if FACEFX_SUPPORT_PS4
 		case EFaceFXTargetPlatform::PS4: return Folder / TEXT("ps4");
-#endif //FACEFX_SUPPORT_PS4
-#if FACEFX_SUPPORT_XBONE
 		case EFaceFXTargetPlatform::XBoxOne: return Folder / TEXT("xboxone");
-#endif //FACEFX_SUPPORT_XBONE
 		default: checkf(false, TEXT("Unknown target platform type"));
 		}
 		return TEXT("");


### PR DESCRIPTION
- Restoring platform data after cook on the runtime asset instance
- Turned target platform data to be available for all config's and use runtime checks instead (UHT doesn't support custom preproc defs)
- Fixed some clang warnings