### PR TITLE
Fix for #93: Support for bone namespace stripping

### DIFF
--- a/Source/FaceFX/Classes/Animation/AnimNode_BlendFaceFXAnimation.h
+++ b/Source/FaceFX/Classes/Animation/AnimNode_BlendFaceFXAnimation.h
@@ -56,6 +56,10 @@ struct FACEFX_API FAnimNode_BlendFaceFXAnimation : public FAnimNode_Base
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category=BlendMode)
 	TEnumAsByte<EBoneModificationMode> ScaleMode;
 
+	/** Indicator if stripped name space bone mapping shall be skipped during bone matching phase in case a bone name was not found */
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category=BoneMapping)
+	bool bSkipBoneMappingWithoutNS;
+
 	// FAnimNode_Base interface
 	virtual void Initialize_AnyThread(const FAnimationInitializeContext& Context) override;
 	virtual void CacheBones_AnyThread(const FAnimationCacheBonesContext & Context) override;

--- a/Source/FaceFX/Private/Animation/AnimNode_BlendFaceFXAnimation.cpp
+++ b/Source/FaceFX/Private/Animation/AnimNode_BlendFaceFXAnimation.cpp
@@ -85,6 +85,7 @@ void FAnimNode_BlendFaceFXAnimation::LoadFaceFXData(FAnimInstanceProxy* AnimInst
 
 		bFaceFXCharacterLoadingCompleted = true;
 
+		//generate the bone mapping indices out of the bone names
 		if(UFaceFXComponent* FaceFXComp = Owner->FindComponentByClass<UFaceFXComponent>())
 		{
 			if(UFaceFXCharacter* FaceFXChar = FaceFXComp->GetCharacter(Component))
@@ -99,7 +100,20 @@ void FAnimNode_BlendFaceFXAnimation::LoadFaceFXData(FAnimInstanceProxy* AnimInst
 					if(BoneTransformIdx != INDEX_NONE)
 					{
 						//find skeleton bone index
-						const int32 BoneIdx = Component->GetBoneIndex(BoneName);
+						int32 BoneIdx = Component->GetBoneIndex(BoneName);
+						
+						if (BoneIdx == INDEX_NONE && !bSkipBoneMappingWithoutNS)
+						{
+							//strip any existing namespace from the bone name and try matching against it
+							FString BoneNameWithOutNS = BoneName.ToString();
+							int32 LastNSLocation;
+							if (BoneNameWithOutNS.FindLastChar(':', LastNSLocation) && BoneNameWithOutNS.Len() > LastNSLocation)
+							{
+								BoneNameWithOutNS = BoneNameWithOutNS.RightChop(LastNSLocation + 1);
+								BoneIdx = Component->GetBoneIndex(*BoneNameWithOutNS);
+							}
+						}
+
 						if(BoneIdx != INDEX_NONE)
 						{
 							const FTransform& BoneRefPose = BoneRefPoses[BoneIdx];


### PR DESCRIPTION
- Adding stripping of namespaces during bone mapping phase in case the bone name was not found
- Toggable via blend node property bSkipBoneMappingWithoutNS