### PR TITLE
Fix for #106: wWise integration requires and imports audio files

### DIFF
--- a/Source/FaceFX/Private/Audio/FaceFXAudio.cpp
+++ b/Source/FaceFX/Private/Audio/FaceFXAudio.cpp
@@ -56,3 +56,12 @@ TSharedPtr<IFaceFXAudio> FFaceFXAudio::Create(UFaceFXCharacter* Owner)
 
 	return MakeShareable(new FFaceFXAudioDefault(Owner));
 }
+
+bool FFaceFXAudio::IsUsingSoundWaveAssets()
+{
+#if WITH_WWISE
+	return PreferredAudioSystem != 1;
+#else
+	return true;
+#endif
+}

--- a/Source/FaceFX/Private/Audio/FaceFXAudio.h
+++ b/Source/FaceFX/Private/Audio/FaceFXAudio.h
@@ -181,6 +181,12 @@ struct FFaceFXAudio
 	*/
 	static TSharedPtr<IFaceFXAudio> Create(UFaceFXCharacter* Owner);
 
+	/** 
+	* Gets the indicator if the active audio system is using sound wave assets
+	* @returns True if sound wave assets are used, else false
+	*/
+	static bool IsUsingSoundWaveAssets();
+
 private:
 
 	FFaceFXAudio(){}

--- a/Source/FaceFX/Private/FaceFXConfig.cpp
+++ b/Source/FaceFX/Private/FaceFXConfig.cpp
@@ -23,6 +23,7 @@ SOFTWARE.
 
 #if WITH_EDITOR
 #include "ConfigCacheIni.h"
+#include "Audio/FaceFXAudio.h"
 
 const FFaceFXConfig& FFaceFXConfig::Get()
 {
@@ -68,6 +69,11 @@ FFaceFXConfig::FFaceFXConfig() : bIsImportLookupAudio(false), bIsImportLookupAni
 	GConfig->GetBool(FACEFX_CONFIG_NS, TEXT("IsImportAudio"), bIsImportAudio, IniFile);
 	GConfig->GetBool(FACEFX_CONFIG_NS, TEXT("IsImportAnimationOnActorImport"), bIsImportAnimationOnActorImport, IniFile);
 	GConfig->GetBool(FACEFX_CONFIG_NS, TEXT("ShowToasterMessageOnIncompatibleAnim"), bShowToasterMessageOnIncompatibleAnim, IniFile);
+}
+
+bool FFaceFXConfig::IsAudioUsingSoundWaveAssets()
+{
+	return FFaceFXAudio::IsUsingSoundWaveAssets();
 }
 
 #endif //WITH_EDITOR

--- a/Source/FaceFX/Public/FaceFXConfig.h
+++ b/Source/FaceFX/Public/FaceFXConfig.h
@@ -175,6 +175,12 @@ struct FACEFX_API FFaceFXConfig
 		return bShowToasterMessageOnIncompatibleAnim;
 	}
 
+	/**
+	* Gets the indicator if the active audio system is using sound wave assets
+	* @returns True if sound wave assets are used, else false
+	*/
+	static bool IsAudioUsingSoundWaveAssets();
+
 private:
 
 	FFaceFXConfig();


### PR DESCRIPTION
- Making audio import success optional. Failure generates a warning instead of an error
- Skip USoundWave audio asset import when wWise is enabled