### PR TITLE
Fix nonunity compile

### DIFF
--- a/Source/FaceFX/FaceFX.Build.cs
+++ b/Source/FaceFX/FaceFX.Build.cs
@@ -32,7 +32,7 @@ public class FaceFX : ModuleRules
     public FaceFX(ReadOnlyTargetRules Target) : base(Target)
 	{
         PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
-        bEnforceIWYU = false;
+        bEnforceIWYU = true;
 
         PrivateDependencyModuleNames.AddRange(
             new string[] {

--- a/Source/FaceFX/Private/Audio/FaceFXAudio.cpp
+++ b/Source/FaceFX/Private/Audio/FaceFXAudio.cpp
@@ -18,14 +18,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
-#include "FaceFX.h"
 #include "FaceFXAudio.h"
+#include "FaceFX.h"
 #include "FaceFXAnim.h"
 
 #include "FaceFXAudioImplDefault.h"
 #if WITH_WWISE
 #include "FaceFXAudioImplWwise.h"
 #endif //WITH_WWISE
+
+#include "HAL/IConsoleManager.h"
 
 //Sound system to use within the FaceFX plugin.If the target sound system is invalid, the default (0, Unreal Audio System) will be used.
 // Supported values :

--- a/Source/FaceFX/Private/Audio/FaceFXAudio.h
+++ b/Source/FaceFX/Private/Audio/FaceFXAudio.h
@@ -22,6 +22,7 @@ SOFTWARE.
 
 #include "FaceFXData.h"
 
+class UActorComponent;
 class UFaceFXCharacter;
 class UFaceFXAnim;
 

--- a/Source/FaceFX/Private/Audio/FaceFXAudioImplDefault.cpp
+++ b/Source/FaceFX/Private/Audio/FaceFXAudioImplDefault.cpp
@@ -18,10 +18,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
-#include "FaceFX.h"
 #include "FaceFXAudioImplDefault.h"
+#include "FaceFX.h"
 #include "Sound/SoundWave.h"
 #include "Components/AudioComponent.h"
+#include "Engine/StreamableManager.h"
+#include "GameFramework/Actor.h"
 
 void FFaceFXAudioDefault::Prepare(const UFaceFXAnim* Animation)
 {

--- a/Source/FaceFX/Private/Audio/FaceFXAudioImplDefault.h
+++ b/Source/FaceFX/Private/Audio/FaceFXAudioImplDefault.h
@@ -21,8 +21,9 @@ SOFTWARE.
 #pragma once
 
 #include "FaceFXAudio.h"
+#include "Components/AudioComponent.h"
 
-class UAudioComponent;
+class UActorComponent;
 
 /** Audio layer that uses the Unreal Audio System */
 struct FFaceFXAudioDefault : public IFaceFXAudio

--- a/Source/FaceFX/Private/Audio/FaceFXAudioImplWwise.cpp
+++ b/Source/FaceFX/Private/Audio/FaceFXAudioImplWwise.cpp
@@ -18,8 +18,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
-#include "FaceFX.h"
 #include "FaceFXAudioImplWwise.h"
+#include "FaceFX.h"
 
 #if WITH_WWISE
 

--- a/Source/FaceFX/Private/FaceFXCharacter.cpp
+++ b/Source/FaceFX/Private/FaceFXCharacter.cpp
@@ -22,9 +22,11 @@
 #include "FaceFX.h"
 #include "FaceFXContext.h"
 #include "FaceFXActor.h"
+#include "Audio/FaceFXAudio.h"
 #include "GameFramework/Actor.h"
 #include "Animation/FaceFXComponent.h"
 #include "Engine/StreamableManager.h"
+#include "Components/SkeletalMeshComponent.h"
 
 DECLARE_CYCLE_STAT(TEXT("Tick FaceFX Character"), STAT_FaceFXTick, STATGROUP_FACEFX);
 DECLARE_CYCLE_STAT(TEXT("Update FaceFX Transforms"), STAT_FaceFXUpdateTransforms, STATGROUP_FACEFX);

--- a/Source/FaceFX/Private/FaceFXConfig.cpp
+++ b/Source/FaceFX/Private/FaceFXConfig.cpp
@@ -18,12 +18,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
-#include "FaceFX.h"
 #include "FaceFXConfig.h"
+#include "FaceFX.h"
 
 #if WITH_EDITOR
 #include "ConfigCacheIni.h"
-#include "Audio/FaceFXAudio.h"
 
 const FFaceFXConfig& FFaceFXConfig::Get()
 {

--- a/Source/FaceFX/Public/FaceFXConfig.h
+++ b/Source/FaceFX/Public/FaceFXConfig.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "CoreMinimal.h"
 #include "Modules/ModuleVersion.h"
 #include "facefx-runtime-1.3.0/facefx/facefx.h"
 

--- a/Source/FaceFXEditor/Classes/Factories/FaceFXAnimFactory.h
+++ b/Source/FaceFXEditor/Classes/Factories/FaceFXAnimFactory.h
@@ -22,6 +22,7 @@
 
 #include "IAssetTypeActions.h"
 #include "Include/Slate/FaceFXStyle.h"
+#include "Factories/Factory.h"
 #include "FaceFXAnimFactory.generated.h"
 
 UCLASS(hidecategories=Object)

--- a/Source/FaceFXEditor/Classes/Sequencer/FaceFXSequencer.h
+++ b/Source/FaceFXEditor/Classes/Sequencer/FaceFXSequencer.h
@@ -20,6 +20,8 @@ SOFTWARE.
 
 #pragma once
 
+#include "CoreMinimal.h"
+
 /** Main entrance for FaceFX sequencer support */
 struct FFaceFXSequencer
 {

--- a/Source/FaceFXEditor/FaceFXEditor.Build.cs
+++ b/Source/FaceFXEditor/FaceFXEditor.Build.cs
@@ -25,7 +25,7 @@ public class FaceFXEditor : ModuleRules
     public FaceFXEditor(ReadOnlyTargetRules Target) : base(Target)
     {
         PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
-        bEnforceIWYU = false;
+        bEnforceIWYU = true;
 
         PrivateDependencyModuleNames.AddRange(
             new string[] {

--- a/Source/FaceFXEditor/Include/Slate/FaceFXComboChoiceWidget.cpp
+++ b/Source/FaceFXEditor/Include/Slate/FaceFXComboChoiceWidget.cpp
@@ -20,7 +20,7 @@
 #include "FaceFXComboChoiceWidget.h"
 #include "FaceFXEditor.h"
 
-
+#include "Editor.h"
 #include "EditorStyleSet.h"
 #include "SScrollBox.h"
 #include "SBorder.h"

--- a/Source/FaceFXEditor/Include/Slate/FaceFXResultWidget.cpp
+++ b/Source/FaceFXEditor/Include/Slate/FaceFXResultWidget.cpp
@@ -22,6 +22,7 @@
 #include "FaceFXEditor.h"
 #include "FaceFXStyle.h"
 #include "EditorStyleSet.h"
+#include "SlateApplication.h"
 #include "SScrollBox.h"
 #include "SBorder.h"
 #include "SBoxPanel.h"
@@ -32,6 +33,8 @@
 #include "SButton.h"
 #include "Margin.h"
 #include "MessageDialog.h"
+#include "MultiBoxBuilder.h"
+#include "Editor.h"
 
 #define LOCTEXT_NAMESPACE "FaceFX"
 

--- a/Source/FaceFXEditor/Include/Slate/FaceFXResultWidget.h
+++ b/Source/FaceFXEditor/Include/Slate/FaceFXResultWidget.h
@@ -20,8 +20,13 @@
 
 #pragma once
 
+#include "CoreMinimal.h"
 #include "SCompoundWidget.h"
 #include "FaceFXEditorTools.h"
+#include "DeclarativeSyntaxSupport.h"
+#include "SListView.h"
+#include "STableRow.h"
+#include "SWindow.h"
 
 /** A widget that wraps a asset reference into a textbox and goto button */
 class FFaceFXAssetRefWidget : public SCompoundWidget

--- a/Source/FaceFXEditor/Include/Slate/FaceFXStyle.cpp
+++ b/Source/FaceFXEditor/Include/Slate/FaceFXStyle.cpp
@@ -19,6 +19,7 @@
 *******************************************************************************/
 
 #include "FaceFXStyle.h"
+#include "FaceFXConfig.h"
 #include "FaceFXEditor.h"
 #include "SlateStyle.h"
 #include "ClassIconFinder.h"

--- a/Source/FaceFXEditor/Include/Slate/FaceFXStyle.h
+++ b/Source/FaceFXEditor/Include/Slate/FaceFXStyle.h
@@ -20,6 +20,10 @@
 
 #pragma once
 
+#include "CoreMinimal.h"
+
+struct FSlateBrush;
+
 /** A wrapper for the FaceFX related slate style sets */
 struct FFaceFXStyle
 {

--- a/Source/FaceFXEditor/Private/AssetTypeActions/AssetTypeActions_FaceFXActor.cpp
+++ b/Source/FaceFXEditor/Private/AssetTypeActions/AssetTypeActions_FaceFXActor.cpp
@@ -23,6 +23,7 @@
 #include "FaceFXEditorTools.h"
 #include "FaceFX.h"
 #include "ModuleManager.h"
+#include "MultiboxBuilder.h"
 #include "IContentBrowserSingleton.h"
 #include "ContentBrowserModule.h"
 

--- a/Source/FaceFXEditor/Private/AssetTypeActions/AssetTypeActions_FaceFXAnim.cpp
+++ b/Source/FaceFXEditor/Private/AssetTypeActions/AssetTypeActions_FaceFXAnim.cpp
@@ -22,6 +22,7 @@
 #include "FaceFX.h"
 #include "IMainFrameModule.h"
 #include "ModuleManager.h"
+#include "MultiBoxBuilder.h"
 #include "IContentBrowserSingleton.h"
 #include "ContentBrowserModule.h"
 

--- a/Source/FaceFXEditor/Private/AssetTypeActions/AssetTypeActions_FaceFXBase.cpp
+++ b/Source/FaceFXEditor/Private/AssetTypeActions/AssetTypeActions_FaceFXBase.cpp
@@ -29,6 +29,7 @@
 #include "DesktopPlatformModule.h"
 #include "ContentBrowserModule.h"
 #include "Dialogs.h"
+#include "Editor.h"
 #include "FeedbackContext.h"
 
 #define LOCTEXT_NAMESPACE "FaceFX"

--- a/Source/FaceFXEditor/Private/FaceFXEditor.cpp
+++ b/Source/FaceFXEditor/Private/FaceFXEditor.cpp
@@ -29,6 +29,7 @@
 #include "Sequencer/FaceFXAnimationTrackEditor.h"
 #include "Matinee/MatineeActor.h"
 #include "EngineUtils.h"
+#include "Editor.h"
 
 #define LOCTEXT_NAMESPACE "FaceFX"
 

--- a/Source/FaceFXEditor/Private/FaceFXEditorTools.cpp
+++ b/Source/FaceFXEditor/Private/FaceFXEditorTools.cpp
@@ -21,6 +21,7 @@
 #include "FaceFXEditorTools.h"
 #include "FaceFXEditor.h"
 #include "FaceFX.h"
+#include "EditorStyleSet.h"
 #include "Include/Slate/FaceFXComboChoiceWidget.h"
 #include "AssetToolsModule.h"
 #include "ObjectTools.h"

--- a/Source/FaceFXEditor/Private/Sequencer/FaceFXAnimationTrackEditor.cpp
+++ b/Source/FaceFXEditor/Private/Sequencer/FaceFXAnimationTrackEditor.cpp
@@ -28,10 +28,12 @@ SOFTWARE.
 #include "MovieScene.h"
 #include "MovieSceneSection.h"
 #include "MovieSceneTrack.h"
+#include "MultiBoxBuilder.h"
 #include "ISequencerSection.h"
 #include "SequencerUtilities.h"
 #include "SequencerSectionPainter.h"
 #include "CommonMovieSceneTools.h"
+#include "GameFramework/Actor.h"
 
 #define LOCTEXT_NAMESPACE "FaceFX"
 

--- a/Source/FaceFXEditor/Public/FaceFXEditorTools.h
+++ b/Source/FaceFXEditor/Public/FaceFXEditorTools.h
@@ -22,6 +22,7 @@
 
 #include "FaceFXData.h"
 #include "FaceFXEditor.h"
+#include "Misc/Paths.h"
 
 #include "FaceFXEditorTools.generated.h"
 


### PR DESCRIPTION
Fix FaceFX to compile in nonunity configuration, and enable bEnforceIWYU in the Build.cs files.

This is especially beneficial since adaptive unity builds are enabled by default now, and so if any FaceFX files don't compile alone, then the compile error will only surface once someone makes a change to them.

Unreal also expects plugins in the Engine directory to conform to the IWYU standards as of 4.16.

https://docs.unrealengine.com/latest/INT/Programming/UnrealBuildSystem/IWYUReferenceGuide/

Also, compiling with

    <bUseUnityBuild>false</bUseUnityBuild>

in BuildConfiguration.xml helps to verify that all files compile on their own, without depending on being bundled into a unity blob with other cpp files.

I believe this fixes #109. I am able to compile it locally in Development Editor Win64 config. I can't test Mac, unfortunately.