### PR TITLE
Rename TAssetPtr & FStringAssetReference

### DIFF
--- a/Source/FaceFX/Classes/Animation/FaceFXComponent.h
+++ b/Source/FaceFX/Classes/Animation/FaceFXComponent.h
@@ -40,7 +40,7 @@ struct FACEFX_API FFaceFXEntry
 	GENERATED_USTRUCT_BODY()
 
 	FFaceFXEntry() : SkelMeshComp(nullptr), AudioComp(nullptr), Character(nullptr), bIsAutoPlaySound(true) {}
-	FFaceFXEntry(USkeletalMeshComponent* InSkelMeshComp, UActorComponent* InAudioComp, const TAssetPtr<class UFaceFXActor>& InAsset, bool InIsAutoPlaySound = true, bool InIsDisableMorphTargets = false) :
+	FFaceFXEntry(USkeletalMeshComponent* InSkelMeshComp, UActorComponent* InAudioComp, const TSoftObjectPtr<class UFaceFXActor>& InAsset, bool InIsAutoPlaySound = true, bool InIsDisableMorphTargets = false) :
 		SkelMeshComp(InSkelMeshComp), AudioComp(InAudioComp), Asset(InAsset), Character(nullptr), bIsAutoPlaySound(InIsAutoPlaySound), bIsDisableMorphTargets(InIsDisableMorphTargets) {}
 
 	/** The linked skelmesh component */
@@ -53,7 +53,7 @@ struct FACEFX_API FFaceFXEntry
 
 	/** The asset to use when instantiating the facial character instance */
 	UPROPERTY(BlueprintReadOnly, EditAnywhere, Category=FaceFX)
-	TAssetPtr<class UFaceFXActor> Asset;
+	TSoftObjectPtr<class UFaceFXActor> Asset;
 
 	/** The FaceFX character instance that was created for this component */
 	UPROPERTY(Transient, BlueprintReadOnly, Category=FaceFX)

--- a/Source/FaceFX/Classes/FaceFXAnim.h
+++ b/Source/FaceFX/Classes/FaceFXAnim.h
@@ -208,7 +208,7 @@ public:
 	* Gets the assigned audio asset
 	* @returns The audio asset
 	*/
-	inline const TAssetPtr<USoundWave>& GetAudio() const
+	inline const TSoftObjectPtr<USoundWave>& GetAudio() const
 	{
 		return Audio;
 	}
@@ -217,7 +217,7 @@ public:
 	* Gets the assigned AK audio asset for Play
 	* @returns The AK audio asset
 	*/
-	inline const TAssetPtr<UObject>& GetAudioAkEvent() const
+	inline const TSoftObjectPtr<UObject>& GetAudioAkEvent() const
 	{
 		return AudioAkEvent;
 	}
@@ -226,7 +226,7 @@ public:
 	* Gets the assigned AK audio asset for Stop
 	* @returns The AK audio asset
 	*/
-	inline const TAssetPtr<UObject>& GetAudioAkEventStop() const
+	inline const TSoftObjectPtr<UObject>& GetAudioAkEventStop() const
 	{
 		return AudioAkEventStop;
 	}
@@ -235,7 +235,7 @@ public:
 	* Gets the assigned AK audio asset for Pause
 	* @returns The AK audio asset
 	*/
-	inline const TAssetPtr<UObject>& GetAudioAkEventPause() const
+	inline const TSoftObjectPtr<UObject>& GetAudioAkEventPause() const
 	{
 		return AudioAkEventPause;
 	}
@@ -244,7 +244,7 @@ public:
 	* Gets the assigned AK audio asset for Resume
 	* @returns The AK audio asset
 	*/
-	inline const TAssetPtr<UObject>& GetAudioAkEventResume() const
+	inline const TSoftObjectPtr<UObject>& GetAudioAkEventResume() const
 	{
 		return AudioAkEventResume;
 	}
@@ -293,23 +293,23 @@ private:
 
 	/** The linked audio asset */
 	UPROPERTY(EditInstanceOnly, Category=Audio)
-	TAssetPtr<USoundWave> Audio;
+	TSoftObjectPtr<USoundWave> Audio;
 
 	/** The linked Wwise audio event asset for: Play */
 	UPROPERTY(EditInstanceOnly, Category=AkAudio)
-	TAssetPtr<UObject> AudioAkEvent;
+	TSoftObjectPtr<UObject> AudioAkEvent;
 
 	/** The linked Wwise audio event asset for: Stop */
 	UPROPERTY(EditInstanceOnly, Category = AkAudio)
-	TAssetPtr<UObject> AudioAkEventStop;
+	TSoftObjectPtr<UObject> AudioAkEventStop;
 
 	/** The linked Wwise audio event asset for: Pause */
 	UPROPERTY(EditInstanceOnly, Category = AkAudio)
-	TAssetPtr<UObject> AudioAkEventPause;
+	TSoftObjectPtr<UObject> AudioAkEventPause;
 
 	/** The linked Wwise audio event asset for: Resume */
 	UPROPERTY(EditInstanceOnly, Category = AkAudio)
-	TAssetPtr<UObject> AudioAkEventResume;
+	TSoftObjectPtr<UObject> AudioAkEventResume;
 
 #if WITH_EDITORONLY_DATA
 
@@ -336,7 +336,7 @@ struct FFaceFXAnimComponentSet
 
 	/** The animation to play */
 	UPROPERTY(EditAnywhere, Category = FaceFX)
-	TAssetPtr<UFaceFXAnim> Animation;
+	TSoftObjectPtr<UFaceFXAnim> Animation;
 
 	inline void Reset()
 	{

--- a/Source/FaceFX/Classes/Matinee/FaceFXMatineeControl.h
+++ b/Source/FaceFX/Classes/Matinee/FaceFXMatineeControl.h
@@ -43,7 +43,7 @@ struct FFaceFXTrackKey
 
 	/** The animation to play */
 	UPROPERTY(EditAnywhere, Category=FaceFX)
-	TAssetPtr<UFaceFXAnim> Animation;
+	TSoftObjectPtr<UFaceFXAnim> Animation;
 
 	/** The time of the key along the track time line */
 	UPROPERTY()

--- a/Source/FaceFX/Classes/Sequencer/FaceFXAnimationSection.h
+++ b/Source/FaceFX/Classes/Sequencer/FaceFXAnimationSection.h
@@ -65,13 +65,13 @@ public:
 	}
 
 	/** Sets the animation asset */
-	inline void SetAnimation(const TAssetPtr<UFaceFXAnim>& Anim)
+	inline void SetAnimation(const TSoftObjectPtr<UFaceFXAnim>& Anim)
 	{
 		Animation = Anim;
 	}
 
 	/** Gets the assigned animation asset */
-	inline const TAssetPtr<UFaceFXAnim>& GetAnimationAsset() const
+	inline const TSoftObjectPtr<UFaceFXAnim>& GetAnimationAsset() const
 	{
 		return Animation;
 	}
@@ -93,7 +93,7 @@ public:
 	* @param Owner The owner of the potentially loaded animation data
 	* @returns The loaded animation, else nullptr if not found or unset
 	*/
-	static UFaceFXAnim* GetAnimation(const TAssetPtr<UFaceFXAnim>& Asset, UObject* Owner = nullptr);
+	static UFaceFXAnim* GetAnimation(const TSoftObjectPtr<UFaceFXAnim>& Asset, UObject* Owner = nullptr);
 
 	/**
 	* Gets the duration of the assigned animation
@@ -197,7 +197,7 @@ private:
 
 	/** The animation to play */
 	UPROPERTY(EditAnywhere, Category = FaceFX)
-	TAssetPtr<UFaceFXAnim> Animation;
+	TSoftObjectPtr<UFaceFXAnim> Animation;
 
 	/** The offset into the beginning of the animation clip */
 	UPROPERTY(EditAnywhere, Category = FaceFX)

--- a/Source/FaceFX/Classes/Sequencer/FaceFXAnimationSectionTemplate.h
+++ b/Source/FaceFX/Classes/Sequencer/FaceFXAnimationSectionTemplate.h
@@ -76,7 +76,7 @@ struct FFaceFXAnimationSectionData
 
 	/** The animation asset set for a section */
 	UPROPERTY()
-	TAssetPtr<UFaceFXAnim> Animation;
+	TSoftObjectPtr<UFaceFXAnim> Animation;
 
 	/** The component ID of that section */
 	UPROPERTY()

--- a/Source/FaceFX/Private/Animation/FaceFXComponent.cpp
+++ b/Source/FaceFX/Private/Animation/FaceFXComponent.cpp
@@ -329,7 +329,7 @@ void UFaceFXComponent::CreateCharacter(FFaceFXEntry& Entry)
 			++NumAsyncLoadRequestsPending;
 
 			//asset not loaded yet -> trigger async load
-			TArray<FStringAssetReference> StreamingRequests;
+			TArray<FSoftObjectPath> StreamingRequests;
 			StreamingRequests.Add(Entry.Asset.ToSoftObjectPath());
 
 			FaceFX::GetStreamer().RequestAsyncLoad(StreamingRequests, FStreamableDelegate::CreateUObject(this, &UFaceFXComponent::OnFaceActorAssetLoaded));

--- a/Source/FaceFX/Private/Audio/FaceFXAudioImplDefault.cpp
+++ b/Source/FaceFX/Private/Audio/FaceFXAudioImplDefault.cpp
@@ -34,7 +34,7 @@ void FFaceFXAudioDefault::Prepare(const UFaceFXAnim* Animation)
 	if (bIsAutoPlaySound && !CurrentAnimSound.IsValid() && CurrentAnimSound.ToSoftObjectPath().IsValid())
 	{
 		//asset not loaded yet -> async load to have it (hopefully) ready when the FaceFX runtime audio start event triggers
-		TArray<FStringAssetReference> StreamingRequests;
+		TArray<FSoftObjectPath> StreamingRequests;
 		StreamingRequests.Add(CurrentAnimSound.ToSoftObjectPath());
 		FaceFX::GetStreamer().RequestAsyncLoad(StreamingRequests, FStreamableDelegate());
 	}

--- a/Source/FaceFX/Private/Audio/FaceFXAudioImplDefault.h
+++ b/Source/FaceFX/Private/Audio/FaceFXAudioImplDefault.h
@@ -82,5 +82,5 @@ private:
 	TWeakObjectPtr<UAudioComponent> AudioComponent;
 
 	/** The current audio asset that was assigned to the current animation*/
-	TAssetPtr<USoundWave> CurrentAnimSound;
+	TSoftObjectPtr<USoundWave> CurrentAnimSound;
 };

--- a/Source/FaceFX/Private/Audio/FaceFXAudioImplWwise.cpp
+++ b/Source/FaceFX/Private/Audio/FaceFXAudioImplWwise.cpp
@@ -32,7 +32,7 @@ SOFTWARE.
 * @param Asset The asset to load
 * @returns The loaded AK event asset
 */
-UAkAudioEvent* GetAkEvent(UFaceFXCharacter* Character, const TAssetPtr<UAkAudioEvent>& Asset)
+UAkAudioEvent* GetAkEvent(UFaceFXCharacter* Character, const TSoftObjectPtr<UAkAudioEvent>& Asset)
 {
 	UAkAudioEvent* SoundEvent = Asset.Get();
 	if (!SoundEvent)
@@ -54,7 +54,7 @@ void FFaceFXAudioWwise::Prepare(const UFaceFXAnim* Animation)
 		CurrentAnimSoundPause = Animation->GetAudioAkEventPause().ToSoftObjectPath();
 		CurrentAnimSoundResume = Animation->GetAudioAkEventResume().ToSoftObjectPath();
 
-		TArray<FStringAssetReference> StreamingRequests;
+		TArray<FSoftObjectPath> StreamingRequests;
 
 		//check if asset are not loaded yet -> async load to have it (hopefully) ready when the FaceFX runtime audio start event triggers
 		if (!CurrentAnimSound.IsValid() && CurrentAnimSound.ToSoftObjectPath().IsValid())

--- a/Source/FaceFX/Private/Audio/FaceFXAudioImplWwise.h
+++ b/Source/FaceFX/Private/Audio/FaceFXAudioImplWwise.h
@@ -84,16 +84,16 @@ private:
 	TWeakObjectPtr<UAkComponent> AudioComponent;
 
 	/** The currently playing AK sound event for Play */
-	TAssetPtr<UAkAudioEvent> CurrentAnimSound;
+	TSoftObjectPtr<UAkAudioEvent> CurrentAnimSound;
 
 	/** The currently playing AK sound event for Stop */
-	TAssetPtr<UAkAudioEvent> CurrentAnimSoundStop;
+	TSoftObjectPtr<UAkAudioEvent> CurrentAnimSoundStop;
 
 	/** The currently playing AK sound event for Pause */
-	TAssetPtr<UAkAudioEvent> CurrentAnimSoundPause;
+	TSoftObjectPtr<UAkAudioEvent> CurrentAnimSoundPause;
 
 	/** The currently playing AK sound event for Resume */
-	TAssetPtr<UAkAudioEvent> CurrentAnimSoundResume;
+	TSoftObjectPtr<UAkAudioEvent> CurrentAnimSoundResume;
 };
 
 #endif //WITH_WWISE

--- a/Source/FaceFX/Private/FaceFXCharacter.cpp
+++ b/Source/FaceFX/Private/FaceFXCharacter.cpp
@@ -236,7 +236,7 @@ bool UFaceFXCharacter::GetAnimationBoundsById(const AActor* Actor, const FFaceFX
 				else if (FxEntry->Asset.IsValid())
 				{
 					//fetch from FaceFX actor
-					if (const UFaceFXActor* FxActor = TAssetPtr<UFaceFXActor>(FxEntry->Asset).LoadSynchronous())
+					if (const UFaceFXActor* FxActor = TSoftObjectPtr<UFaceFXActor>(FxEntry->Asset).LoadSynchronous())
 					{
 						return UFaceFXCharacter::GetAnimationBoundsById(FxActor, AnimId, OutStart, OutEnd);
 					}

--- a/Source/FaceFX/Private/Sequencer/FaceFXAnimationSection.cpp
+++ b/Source/FaceFX/Private/Sequencer/FaceFXAnimationSection.cpp
@@ -99,7 +99,7 @@ void UFaceFXAnimationSection::GetSnapTimes(TArray<float>& OutSnapTimes, bool bGe
 	}
 }
 
-UFaceFXAnim* UFaceFXAnimationSection::GetAnimation(const TAssetPtr<UFaceFXAnim>& Asset, UObject* Owner)
+UFaceFXAnim* UFaceFXAnimationSection::GetAnimation(const TSoftObjectPtr<UFaceFXAnim>& Asset, UObject* Owner)
 {
 	UFaceFXAnim* NewAnim = Asset.Get();
 	if (!NewAnim && Asset.ToSoftObjectPath().IsValid())

--- a/Source/FaceFXEditor/Include/Slate/FaceFXResultWidget.cpp
+++ b/Source/FaceFXEditor/Include/Slate/FaceFXResultWidget.cpp
@@ -89,7 +89,7 @@ void FFaceFXAssetRefWidget::Construct(const FArguments& Args)
 	];
 }
 
-FReply FFaceFXAssetRefWidget::OnClicked(FStringAssetReference InAssetRef)
+FReply FFaceFXAssetRefWidget::OnClicked(FSoftObjectPath InAssetRef)
 {
 	FFaceFXEditorTools::ContentBrowserFocusAsset(InAssetRef);
 	return FReply::Handled();

--- a/Source/FaceFXEditor/Include/Slate/FaceFXResultWidget.h
+++ b/Source/FaceFXEditor/Include/Slate/FaceFXResultWidget.h
@@ -33,14 +33,14 @@ class FFaceFXAssetRefWidget : public SCompoundWidget
 {
 public:
 	SLATE_BEGIN_ARGS(FFaceFXAssetRefWidget){}
-	SLATE_ARGUMENT(FStringAssetReference, AssetRef)
+	SLATE_ARGUMENT(FSoftObjectPath, AssetRef)
 	SLATE_END_ARGS()
 
 	void Construct(const FArguments& Args);
 
 private:
 
-	FReply OnClicked(FStringAssetReference InAssetRef);
+	FReply OnClicked(FSoftObjectPath InAssetRef);
 };
 
 /** A widget that shows the Import result data */
@@ -51,7 +51,7 @@ class FFaceFXResultWidget : public SCompoundWidget
 		FFaceFXImportActionResult Result;
 
 		/** The root action that initially requested the import */
-		TAssetPtr<class UFaceFXAsset> ImportRootAsset;
+		TSoftObjectPtr<class UFaceFXAsset> ImportRootAsset;
 	};
 
 	/** Widget used to display the table rows */

--- a/Source/FaceFXEditor/Private/FaceFXEditorTools.cpp
+++ b/Source/FaceFXEditor/Private/FaceFXEditorTools.cpp
@@ -1065,7 +1065,7 @@ bool FFaceFXEditorTools::LoadAudio(UFaceFXAnim* Asset, const FString& Folder, FF
 	return false;
 }
 
-TAssetPtr<USoundWave> FFaceFXEditorTools::LocateAudio(const FString& AudioSourceFile)
+TSoftObjectPtr<USoundWave> FFaceFXEditorTools::LocateAudio(const FString& AudioSourceFile)
 {
 	TArray<FAssetData> SoundAssets;
 
@@ -1158,7 +1158,7 @@ bool FFaceFXEditorTools::InitializeFromFile(UFaceFXAsset* Asset, const FString& 
 	return Result;
 }
 
-void FFaceFXEditorTools::ContentBrowserFocusAsset(const FStringAssetReference& Asset)
+void FFaceFXEditorTools::ContentBrowserFocusAsset(const FSoftObjectPath& Asset)
 {
 	//UObject* AssetObj = Asset.ResolveObject();
 	UObject* AssetObj = nullptr;

--- a/Source/FaceFXEditor/Public/FaceFXEditorTools.h
+++ b/Source/FaceFXEditor/Public/FaceFXEditorTools.h
@@ -48,7 +48,7 @@ struct FFaceFXImportActionResult
 	};
 
 	FFaceFXImportActionResult() : Type(ActionType::None), Result(ResultType::Error) {}
-	FFaceFXImportActionResult(ActionType InType, ResultType InResult, const TAssetPtr<class UFaceFXAsset>& InImportAsset = nullptr, const FText& InMessage = FText::GetEmpty()) :
+	FFaceFXImportActionResult(ActionType InType, ResultType InResult, const TSoftObjectPtr<class UFaceFXAsset>& InImportAsset = nullptr, const FText& InMessage = FText::GetEmpty()) :
 		Type(InType), Result(InResult), Message(InMessage), ImportAsset(InImportAsset) {}
 
 	/**
@@ -88,7 +88,7 @@ struct FFaceFXImportActionResult
 	* Gets the assigned asset
 	* @returns The asset
 	*/
-	inline const TAssetPtr<UObject>& GetAsset() const
+	inline const TSoftObjectPtr<UObject>& GetAsset() const
 	{
 		return Asset;
 	}
@@ -97,7 +97,7 @@ struct FFaceFXImportActionResult
 	* Sets the assigned asset
 	* @param InAsset The new asset
 	*/
-	inline void SetAsset(const TAssetPtr<UObject>& InAsset)
+	inline void SetAsset(const TSoftObjectPtr<UObject>& InAsset)
 	{
 		Asset = InAsset;
 	}
@@ -107,7 +107,7 @@ struct FFaceFXImportActionResult
 	* Gets the assigned import asset
 	* @returns The import asset
 	*/
-	inline const TAssetPtr<UFaceFXAsset>& GetImportAsset() const
+	inline const TSoftObjectPtr<UFaceFXAsset>& GetImportAsset() const
 	{
 		return ImportAsset;
 	}
@@ -133,10 +133,10 @@ private:
 	FText Message;
 
 	/** The affected asset */
-	TAssetPtr<UObject> Asset;
+	TSoftObjectPtr<UObject> Asset;
 
 	/** The asset for which the action was performed */
-	TAssetPtr<class UFaceFXAsset> ImportAsset;
+	TSoftObjectPtr<class UFaceFXAsset> ImportAsset;
 };
 
 /** A whole result set for a complete import process */
@@ -145,7 +145,7 @@ struct FFaceFXImportResult
 {
 	GENERATED_USTRUCT_BODY()
 
-	FFaceFXImportResult(const TAssetPtr<class UFaceFXAsset>& InImportRootAsset = nullptr) : ImportRootAsset(InImportRootAsset) {}
+	FFaceFXImportResult(const TSoftObjectPtr<class UFaceFXAsset>& InImportRootAsset = nullptr) : ImportRootAsset(InImportRootAsset) {}
 
 	/**
 	* Adds a new message to the result set
@@ -157,7 +157,7 @@ struct FFaceFXImportResult
 	* @returns The added result entry
 	*/
 	template <typename TAssetType = UObject>
-	FFaceFXImportActionResult& Add(const FText& Message, FFaceFXImportActionResult::ActionType Type, FFaceFXImportActionResult::ResultType Result, const TAssetPtr<class UFaceFXAsset>& ImportAsset, const TAssetPtr<TAssetType>& InAsset = nullptr)
+	FFaceFXImportActionResult& Add(const FText& Message, FFaceFXImportActionResult::ActionType Type, FFaceFXImportActionResult::ResultType Result, const TSoftObjectPtr<class UFaceFXAsset>& ImportAsset, const TSoftObjectPtr<TAssetType>& InAsset = nullptr)
 	{
 		FFaceFXImportActionResult NewEntry = FFaceFXImportActionResult(Type, Result, ImportAsset, Message);
 		NewEntry.Asset = InAsset.ToSoftObjectPath();
@@ -172,7 +172,7 @@ struct FFaceFXImportResult
 	* @returns The added result entry
 	*/
 	template <typename TAssetType = UObject>
-	FFaceFXImportActionResult& AddModifyError(const FText& Message, const TAssetPtr<class UFaceFXAsset>& ImportAsset = nullptr, const TAssetPtr<TAssetType>& InAsset = nullptr)
+	FFaceFXImportActionResult& AddModifyError(const FText& Message, const TSoftObjectPtr<class UFaceFXAsset>& ImportAsset = nullptr, const TSoftObjectPtr<TAssetType>& InAsset = nullptr)
 	{
 		return Add(Message, FFaceFXImportActionResult::ActionType::Modify, FFaceFXImportActionResult::ResultType::Error, ImportAsset, InAsset);
 	}
@@ -185,7 +185,7 @@ struct FFaceFXImportResult
 	* @returns The added result entry
 	*/
 	template <typename TAssetType = UObject>
-	FFaceFXImportActionResult& AddCreateError(const FText& Message, const TAssetPtr<class UFaceFXAsset>& ImportAsset = nullptr, const TAssetPtr<TAssetType>& InAsset = nullptr)
+	FFaceFXImportActionResult& AddCreateError(const FText& Message, const TSoftObjectPtr<class UFaceFXAsset>& ImportAsset = nullptr, const TSoftObjectPtr<TAssetType>& InAsset = nullptr)
 	{
 		return Add(Message, FFaceFXImportActionResult::ActionType::Create, FFaceFXImportActionResult::ResultType::Error, ImportAsset, InAsset);
 	}
@@ -198,7 +198,7 @@ struct FFaceFXImportResult
 	* @returns The added result entry
 	*/
 	template <typename TAssetType = UObject>
-	FFaceFXImportActionResult& AddModifyWarning(const FText& Message, const TAssetPtr<class UFaceFXAsset>& ImportAsset = nullptr, const TAssetPtr<TAssetType>& InAsset = nullptr)
+	FFaceFXImportActionResult& AddModifyWarning(const FText& Message, const TSoftObjectPtr<class UFaceFXAsset>& ImportAsset = nullptr, const TSoftObjectPtr<TAssetType>& InAsset = nullptr)
 	{
 		return Add(Message, FFaceFXImportActionResult::ActionType::Modify, FFaceFXImportActionResult::ResultType::Warning, ImportAsset, InAsset);
 	}
@@ -211,7 +211,7 @@ struct FFaceFXImportResult
 	* @returns The added result entry
 	*/
 	template <typename TAssetType = UObject>
-	FFaceFXImportActionResult& AddCreateWarning(const FText& Message, const TAssetPtr<class UFaceFXAsset>& ImportAsset = nullptr, const TAssetPtr<TAssetType>& InAsset = nullptr)
+	FFaceFXImportActionResult& AddCreateWarning(const FText& Message, const TSoftObjectPtr<class UFaceFXAsset>& ImportAsset = nullptr, const TSoftObjectPtr<TAssetType>& InAsset = nullptr)
 	{
 		return Add(Message, FFaceFXImportActionResult::ActionType::Create, FFaceFXImportActionResult::ResultType::Warning, ImportAsset, InAsset);
 	}
@@ -224,7 +224,7 @@ struct FFaceFXImportResult
 	* @returns The added result entry
 	*/
 	template <typename TAssetType = UObject>
-	FFaceFXImportActionResult& AddModifySuccess(const FText& Message, const TAssetPtr<class UFaceFXAsset>& ImportAsset = nullptr, const TAssetPtr<TAssetType>& InAsset = nullptr)
+	FFaceFXImportActionResult& AddModifySuccess(const FText& Message, const TSoftObjectPtr<class UFaceFXAsset>& ImportAsset = nullptr, const TSoftObjectPtr<TAssetType>& InAsset = nullptr)
 	{
 		return Add(Message, FFaceFXImportActionResult::ActionType::Modify, FFaceFXImportActionResult::ResultType::Success, ImportAsset, InAsset);
 	}
@@ -237,7 +237,7 @@ struct FFaceFXImportResult
 	* @returns The added result entry
 	*/
 	template <typename TAssetType = UObject>
-	FFaceFXImportActionResult& AddCreateSuccess(const FText& Message, const TAssetPtr<class UFaceFXAsset>& ImportAsset = nullptr, const TAssetPtr<TAssetType>& InAsset = nullptr)
+	FFaceFXImportActionResult& AddCreateSuccess(const FText& Message, const TSoftObjectPtr<class UFaceFXAsset>& ImportAsset = nullptr, const TSoftObjectPtr<TAssetType>& InAsset = nullptr)
 	{
 		return Add(Message, FFaceFXImportActionResult::ActionType::Create, FFaceFXImportActionResult::ResultType::Success, ImportAsset, InAsset);
 	}
@@ -255,7 +255,7 @@ struct FFaceFXImportResult
 	* Gets the import root asset
 	* @returns The root asset
 	*/
-	inline const TAssetPtr<class UFaceFXAsset>& GetImportRootAsset() const
+	inline const TSoftObjectPtr<class UFaceFXAsset>& GetImportRootAsset() const
 	{
 		return ImportRootAsset;
 	}
@@ -282,7 +282,7 @@ struct FFaceFXImportResult
 		return Result;
 	}
 
-	FORCEINLINE bool operator==(const TAssetPtr<class UFaceFXAsset>& Asset) const
+	FORCEINLINE bool operator==(const TSoftObjectPtr<class UFaceFXAsset>& Asset) const
 	{
 		return ImportRootAsset == Asset;
 	}
@@ -293,7 +293,7 @@ private:
 	TArray<FFaceFXImportActionResult> Entries;
 
 	/** The root action that initially requested the import */
-	TAssetPtr<class UFaceFXAsset> ImportRootAsset;
+	TSoftObjectPtr<class UFaceFXAsset> ImportRootAsset;
 };
 
 /** A list of multiple import results per asset */
@@ -304,7 +304,7 @@ struct FFaceFXImportResultSet
 	* @param Asset The current root asset
 	* @returns The new or existing entry
 	*/
-	inline FFaceFXImportResult& GetOrAdd(const TAssetPtr<class UFaceFXAsset>& Asset)
+	inline FFaceFXImportResult& GetOrAdd(const TSoftObjectPtr<class UFaceFXAsset>& Asset)
 	{
 		if(FFaceFXImportResult* Entry = Entries.FindByKey(Asset))
 		{
@@ -313,7 +313,7 @@ struct FFaceFXImportResultSet
 		return Entries[Entries.Add(FFaceFXImportResult(Asset))];
 	}
 
-	inline const FFaceFXImportResult* GetResult(const TAssetPtr<class UFaceFXAsset>& Asset) const
+	inline const FFaceFXImportResult* GetResult(const TSoftObjectPtr<class UFaceFXAsset>& Asset) const
 	{
 		return Entries.FindByKey(Asset);
 	}
@@ -561,7 +561,7 @@ struct FACEFXEDITOR_API FFaceFXEditorTools
 	* Sets the focus on a given asset within the content browser
 	* @param Asset The asset to focus
 	*/
-	static void ContentBrowserFocusAsset(const FStringAssetReference& Asset);
+	static void ContentBrowserFocusAsset(const FSoftObjectPath& Asset);
 
 	/**
 	* Deletes the gives asset
@@ -617,7 +617,7 @@ private:
 	/**
 	* Locates the USoundWave asset that was generated out of the given audio source file
 	* @param AudioSourceFile The absolute source file path to the audio file
-	* @returns The asset that was generated using that audio source or unassigned TAssetPtr if not found
+	* @returns The asset that was generated using that audio source or unassigned TSoftObjectPtr if not found
 	*/
-	static TAssetPtr<class USoundWave> LocateAudio(const FString& AudioSourceFile);
+	static TSoftObjectPtr<class USoundWave> LocateAudio(const FString& AudioSourceFile);
 };


### PR DESCRIPTION
Epic renamed these in 4.18, but did so outside of their normal
deprecation procedure -- so this was overlooked in the update to UE
4.18.

Fixes #112