### PR TITLE
Fix for #120: Support absolute audio paths in .ffxamap files

### DIFF
--- a/Source/FaceFX/Classes/FaceFXAnim.h
+++ b/Source/FaceFX/Classes/FaceFXAnim.h
@@ -74,15 +74,7 @@ public:
 	* @param OutResult The absolute path when the function returns true. Unchanged if it returns false
 	* @returns True if the path is set and OutResult was updated, else false
 	*/
-	inline bool GetAbsoluteAudioPath(FString& OutResult) const
-	{
-		if(!AudioPath.IsEmpty())
-		{
-			OutResult = GetAssetFolder() / AudioPath;
-			return true;
-		}
-		return false;
-	}
+	bool GetAbsoluteAudioPath(FString& OutResult) const;
 
 	/**
 	* Gets the relative audio path that is currently set

--- a/Source/FaceFX/Private/FaceFXAnim.cpp
+++ b/Source/FaceFX/Private/FaceFXAnim.cpp
@@ -21,11 +21,22 @@
 #include "FaceFXAnim.h"
 #include "FaceFX.h"
 #include "Sound/SoundWave.h"
+#include "Misc/Paths.h"
 
 #define LOCTEXT_NAMESPACE "FaceFX"
 
 UFaceFXAnim::UFaceFXAnim(const class FObjectInitializer& PCIP) : Super(PCIP)
 {
+}
+
+bool UFaceFXAnim::GetAbsoluteAudioPath(FString& OutResult) const
+{
+	if (!AudioPath.IsEmpty())
+	{
+		OutResult = FPaths::IsRelative(AudioPath) ? GetAssetFolder() / AudioPath : AudioPath;
+		return true;
+	}
+	return false;
 }
 
 void UFaceFXAnim::GetResourceSizeEx(FResourceSizeEx& CumulativeResourceSize)


### PR DESCRIPTION
- Added handling of absolute annd relative audio file paths