### PR TITLE
 Fix for #133: Memory blocks used to create FaceFX Runtime handles are invalidated during cooking

### DIFF
--- a/Source/FaceFX/Private/FaceFXAsset.cpp
+++ b/Source/FaceFX/Private/FaceFXAsset.cpp
@@ -92,8 +92,11 @@ template <typename T> bool UFaceFXAsset::ClearPlatformData(const FArchive& Ar, T
 
 	PlatformData.Swap(0, TargetIdx);
 
-	//remove anything but the first position
-	PlatformData.RemoveAt(1, PlatformData.Num() - 1, false);
+	if (PlatformData.Num() > 1)
+	{
+		//remove anything but the first position
+		PlatformData.RemoveAt(1, PlatformData.Num() - 1, false);
+	}
 
 	return true;
 }

--- a/Source/FaceFX/Private/FaceFXAsset.cpp
+++ b/Source/FaceFX/Private/FaceFXAsset.cpp
@@ -93,7 +93,7 @@ template <typename T> bool UFaceFXAsset::ClearPlatformData(const FArchive& Ar, T
 	PlatformData.Swap(0, TargetIdx);
 
 	//remove anything but the first position
-	PlatformData.RemoveAt(1, PlatformData.Num() - 1);
+	PlatformData.RemoveAt(1, PlatformData.Num() - 1, false);
 
 	return true;
 }


### PR DESCRIPTION
- Maintain vector size during cook data adjustments so restoring won't realloc memory
- dealing with RemoveAt issue when there is only one platform data entry