### PR TITLE
Fix for #140: Automate (re)import of facefx asset with commandlet

### DIFF
--- a/Source/FaceFXEditor/Include/Slate/FaceFXResultWidget.cpp
+++ b/Source/FaceFXEditor/Include/Slate/FaceFXResultWidget.cpp
@@ -280,6 +280,12 @@ EAppReturnType::Type FFaceFXResultWidget::OpenDialog(const FText& InTitle, bool 
 
 EAppReturnType::Type FFaceFXResultWidget::Create(const FText& InTitle, const FFaceFXImportResultSet& ResultSet, bool ShowAsModal, bool MergeWithOpenWindow)
 {
+	if (!FSlateApplication::IsInitialized())
+	{
+		//slate less mode (i.e. importasset commandlet)
+		return EAppReturnType::Ok;
+	}
+
 	if(ResultSet.GetEntries().Num() == 0)
 	{
 		//nothing to display

--- a/Source/FaceFXEditor/Private/Factories/FaceFXActorFactory.cpp
+++ b/Source/FaceFXEditor/Private/Factories/FaceFXActorFactory.cpp
@@ -79,9 +79,9 @@ void UFaceFXActorFactory::HandleFaceFXActorCreated(UFaceFXActor* Asset, const FS
 {
 	check(Asset);
 
-	if(!UFaceFXEditorConfig::Get().IsImportAnimationOnActorImport())
+	if(!UFaceFXEditorConfig::Get().IsImportAnimationOnActorImport() || !FSlateApplication::IsInitialized())
 	{
-		//animation import disabled
+		//animation import disabled or slate less mode (i.e. importasset commandlet). In that case we only import the target asset
 		return;
 	}
 


### PR DESCRIPTION
- Prevent any slate related UI in slate less modes (i.e. commandlets)