### PR TITLE
Fix ContainsNaN() in non-unity debug builds

### DIFF
--- a/Source/FaceFX/Private/Animation/AnimNode_BlendFaceFXAnimation.cpp
+++ b/Source/FaceFX/Private/Animation/AnimNode_BlendFaceFXAnimation.cpp
@@ -176,6 +176,19 @@ void FAnimNode_BlendFaceFXAnimation::Evaluate_AnyThread(FPoseContext& Output)
 #endif
 }
 
+bool FaceFXContainsNaN(const TArray<FBoneTransform>& BoneTransforms)
+{
+	for (int32 i = 0; i < BoneTransforms.Num(); ++i)
+	{
+		if (BoneTransforms[i].Transform.ContainsNaN())
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
 void FAnimNode_BlendFaceFXAnimation::EvaluateComponentSpace_AnyThread(FComponentSpacePoseContext& Output)
 {
 	SCOPE_CYCLE_COUNTER(STAT_FaceFXBlend);
@@ -294,7 +307,7 @@ void FAnimNode_BlendFaceFXAnimation::EvaluateComponentSpace_AnyThread(FComponent
 					FAnimationRuntime::ConvertBoneSpaceTransformToCS(FTransform::Identity, Output.Pose, BoneTM, CompactPoseBoneIndex, EBoneControlSpace::BCS_ParentBoneSpace);
 
 					//sanity check
-					checkSlow(!ContainsNaN(TargetBlendTransform));
+					checkSlow(!FaceFXContainsNaN(TargetBlendTransform));
 
 					//apply to pose after each bone transform update in order to have proper parent transforms when update childs
 					Output.Pose.LocalBlendCSBoneTransforms(TargetBlendTransform, BlendWeight);


### PR DESCRIPTION
This patch introduces our own uniquely named version of ContainsNaN()
(FaceFXContainsNan()) that takes a const TArray<FBoneTransform>&. This
should fix non-unity debug builds while keeping unity cooked builds
compiling.

Refs. #121 #123 #124