### PR TITLE
Fix for #155: Global and per FaceFXActor asset blend modes

### DIFF
--- a/Source/FaceFX/Classes/Animation/AnimNode_BlendFaceFXAnimation.h
+++ b/Source/FaceFX/Classes/Animation/AnimNode_BlendFaceFXAnimation.h
@@ -27,6 +27,7 @@
 #include "AnimNode_BlendFaceFXAnimation.generated.h"
 
 struct FAnimInstanceProxy;
+enum class EFaceFXBlendMode : uint8;
 
 /** Anim graph node that blends in facial animation bone transforms into the pose */
 USTRUCT(BlueprintType)
@@ -43,18 +44,6 @@ struct FACEFX_API FAnimNode_BlendFaceFXAnimation : public FAnimNode_Base
 	/** The strength of blending in the facial animation. Will be capped to .0F to 1.F */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category=BlendMode, meta=(PinShownByDefault, UIMin=0.F, UIMax=1.F))
 	float Alpha;
-
-	/** Whether and how to modify the translation of this bone. */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category=BlendMode)
-	TEnumAsByte<EBoneModificationMode> TranslationMode;
-
-	/** Whether and how to modify the translation of this bone. */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category=BlendMode)
-	TEnumAsByte<EBoneModificationMode> RotationMode;
-
-	/** Whether and how to modify the translation of this bone. */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category=BlendMode)
-	TEnumAsByte<EBoneModificationMode> ScaleMode;
 
 	/** Indicator if stripped name space bone mapping shall be skipped during bone matching phase in case a bone name was not found */
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category=BoneMapping)
@@ -101,6 +90,8 @@ private:
 
 	/** Indicator if the async loading process of the FaceFX character has completed. */
 	uint8 bFaceFXCharacterLoadingCompleted : 1;
+
+	EFaceFXBlendMode BlendMode;
 
 #if !UE_BUILD_SHIPPING
 	/** TODO: Remove again once engine issue have been localized */

--- a/Source/FaceFX/Classes/FaceFXActor.h
+++ b/Source/FaceFX/Classes/FaceFXActor.h
@@ -25,8 +25,22 @@
 #include "FaceFXData.h"
 #include "FaceFXActor.generated.h"
 
+/** Blend mode for FaceFX runtime that is set per actor asset */
+UENUM()
+enum class EFaceFXActorBlendMode : uint8
+{
+	/** The global settings are used as blend mode. See FaceFXConfig.h, FACEFX_DEFAULT_BLEND_MODE */
+	Global UMETA(DisplayName = "Use Global Config"),
+
+	/** Overwrite global settings with replace mode. The modifier replaces the existing translation, rotation, or scale. */
+	Replace UMETA(DisplayName = "Replace Existing"),
+
+	/** Overwrite global settings with additive mode. The modifier adds to the existing translation, rotation, or scale. */
+	Additive UMETA(DisplayName = "Add to Existing")
+};
+
 /** Asset that can be assigned to FaceFXComponents and which contain the FaceFX runtime data */
-UCLASS(hideCategories=Object)
+UCLASS(BlueprintType, hideCategories=Object)
 class FACEFX_API UFaceFXActor : public UFaceFXAsset
 {
 	GENERATED_UCLASS_BODY()
@@ -40,6 +54,11 @@ public:
 	virtual bool IsValid() const override
 	{
 		return Super::IsValid() && ActorData.IsValid();
+	}
+
+	inline EFaceFXActorBlendMode GetBlendMode() const
+	{
+		return BlendMode;
 	}
 
 #if WITH_EDITORONLY_DATA
@@ -114,4 +133,8 @@ private:
 	/** The linked animations where this set look up the animations in */
 	UPROPERTY(EditInstanceOnly, Category=FaceFX)
 	TArray<class UFaceFXAnim*> Animations;
+
+	/** The linked animations where this set look up the animations in */
+	UPROPERTY(EditAnywhere, Category = FaceFX)
+	EFaceFXActorBlendMode BlendMode = EFaceFXActorBlendMode::Global;
 };

--- a/Source/FaceFX/Classes/FaceFXCharacter.h
+++ b/Source/FaceFX/Classes/FaceFXCharacter.h
@@ -279,6 +279,11 @@ public:
 		return AudioPlayer.Get();
 	}
 
+	inline EFaceFXBlendMode GetBlendMode() const
+	{
+		return BlendMode;
+	}
+
 	/**
 	* Gets the list of bone names
 	* @returns The list of bone names
@@ -552,6 +557,9 @@ private:
 
 	/** The animation playback state */
 	EPlaybackState AnimPlaybackState;
+
+	/** Used blend mode. Either defined by global config or overriden via FaceFXActor */
+	EFaceFXBlendMode BlendMode;
 
 	/** Dirty indicator */
 	uint8 bIsDirty : 1;

--- a/Source/FaceFX/Public/FaceFXConfig.h
+++ b/Source/FaceFX/Public/FaceFXConfig.h
@@ -24,6 +24,8 @@
 #include "Runtime/Launch/Resources/Version.h"
 #include "FaceFXLib/facefx-runtime-1.5.0/facefx/facefx.h"
 
+#include "FaceFXConfig.generated.h"
+
 // The number of total FaceFX channels. One channel per animation we want to be
 // able to play at once per FaceFXCharacter. Default Value: 1
 #define FACEFX_CHANNELS 1
@@ -99,3 +101,46 @@
 #error                                                                         \
     "FaceFX Sequencer support requires Unreal Engine 4.12 or higher. Please update your engine or use a previous version of the plugin.";
 #endif
+
+
+/** Blend mode for FaceFX runtime */
+UENUM()
+enum class EFaceFXBlendMode : uint8
+{
+	/** Overwrite global settings with replace mode. The modifier replaces the existing translation, rotation, or scale. */
+	Replace UMETA(DisplayName = "Replace Existing"),
+
+	/** Overwrite global settings with additive mode. The modifier adds to the existing translation, rotation, or scale. */
+	Additive UMETA(DisplayName = "Add to Existing")
+};
+
+/** Settings for the game which are exposed to the project plugin config screen */
+UCLASS(config = Game, defaultconfig)
+class FACEFX_API UFaceFXConfig : public UObject
+{
+	GENERATED_BODY()
+
+public:
+
+	static const UFaceFXConfig& Get()
+	{
+		const UFaceFXConfig* Instance = GetDefault<UFaceFXConfig>();
+		check(Instance);
+		return *Instance;
+	}
+
+	inline EFaceFXBlendMode GetDefaultBlendMode() const
+	{
+		return DefaultBlendMode;
+	}
+
+private:
+
+	/* 
+	Default blend mode for the FaceFX runtime evaluation. 
+This setting determines if the runtime is using absolute (replace mode) or offset (additive mode) transforms
+Can be overridden directly via an FaceFXActor asset properties.
+	*/
+	UPROPERTY(config, EditAnywhere, Category = FaceFX)
+	EFaceFXBlendMode DefaultBlendMode = EFaceFXBlendMode::Replace;
+};

--- a/Source/FaceFXEditor/Private/FaceFXEditor.cpp
+++ b/Source/FaceFXEditor/Private/FaceFXEditor.cpp
@@ -206,8 +206,8 @@ private:
 	{
 		if (ISettingsModule* SettingsModule = FModuleManager::GetModulePtr<ISettingsModule>("Settings"))
 		{
-			SettingsModule->RegisterSettings("Project", "Plugins", "FaceFX",
-				LOCTEXT("FaceFXSettingsName", "FaceFX"),
+			SettingsModule->RegisterSettings("Project", "Plugins", "FaceFX - Editor",
+				LOCTEXT("FaceFXSettingsName", "FaceFX - Editor"),
 				LOCTEXT("FaceFXSettingsDescription", "Configure FaceFX editor settings"),
 				GetMutableDefault<UFaceFXEditorConfig>());
 		}
@@ -217,7 +217,7 @@ private:
 	{
 		if (ISettingsModule* SettingsModule = FModuleManager::GetModulePtr<ISettingsModule>("Settings"))
 		{
-			SettingsModule->UnregisterSettings("Project", "Plugins", "FaceFX");
+			SettingsModule->UnregisterSettings("Project", "Plugins", "FaceFX - Editor");
 		}
 	}
 


### PR DESCRIPTION
- moved blend mode from AnimBP blend nodes into a global config which defined a default blending which can be overridden by FaceFXActor assets using the bulk property editor