### PR TITLE
Add basic LOD support

### DIFF
--- a/Source/FaceFX/Classes/Animation/AnimNode_BlendFaceFXAnimation.h
+++ b/Source/FaceFX/Classes/Animation/AnimNode_BlendFaceFXAnimation.h
@@ -49,12 +49,18 @@ struct FACEFX_API FAnimNode_BlendFaceFXAnimation : public FAnimNode_Base
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category=BoneMapping)
 	bool bSkipBoneMappingWithoutNS;
 
+	// @todo What about the transitions where the node becomes active / inactive?
+	/** The maximum LOD setting under which this node is allowed to run. Defaults to all LOD settings. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Performance, meta = (DisplayName = "LOD Threshold"))
+	int32 LODThreshold;
+
 	// FAnimNode_Base interface
 	virtual void Initialize_AnyThread(const FAnimationInitializeContext& Context) override;
 	virtual void CacheBones_AnyThread(const FAnimationCacheBonesContext & Context) override;
 	virtual void Update_AnyThread(const FAnimationUpdateContext& Context) override;
 	virtual void Evaluate_AnyThread(FPoseContext& Output) override;
 	virtual void EvaluateComponentSpace_AnyThread(FComponentSpacePoseContext& Output) override;
+	virtual int32 GetLODThreshold() const override { return LODThreshold; }
 	// End of FAnimNode_Base interface
 
 private:


### PR DESCRIPTION
This patch adds "basic" LOD support:

- Ignore bones missing in current LOD
- Add LODThreshold support to AnimNode_BlendFaceFXAnimation
- Move FaceFX data loading from CacheBones_AnyThread to Initialize_AnyThread

Open questions:

- What to do at transitions between the FaceFX blend node being active and inactive when LOD changes?
- Was there any particular reason the FaceFX data load was in CacheBones_AnyThread?
