### PR TITLE
Enabled audio fade out

### DIFF
--- a/Source/FaceFX/Private/Audio/FaceFXAudio.h
+++ b/Source/FaceFX/Private/Audio/FaceFXAudio.h
@@ -141,6 +141,24 @@ struct IFaceFXAudio
 		return PlaybackState != EPlaybackState::Stopped;
 	}
 
+	/**
+	* Gets the indicator if the audio is currently paused
+	* @returns True if paused, else false
+	*/
+	inline bool IsPaused() const
+	{
+		return PlaybackState != EPlaybackState::Paused;
+	}
+
+	/**
+	* Gets the indicator if the audio is currently stopped
+	* @returns True if stopped, else false
+	*/
+	inline bool IsStopped() const
+	{
+		return PlaybackState == EPlaybackState::Stopped;
+	}
+
 	/** 
 	* Gets the owning component of this audio player 
 	* @returns The owning component or nullptr


### PR DESCRIPTION
- Reenabled audio fade out again after it broke with UE4.17
- Removed UI sound state