### PR TITLE
Support for FaceFX Events

### DIFF
--- a/Source/FaceFX/Private/FaceFXCharacter.cpp
+++ b/Source/FaceFX/Private/FaceFXCharacter.cpp
@@ -33,12 +33,18 @@ DECLARE_CYCLE_STAT(TEXT("Tick Character"), STAT_FaceFXTick, STATGROUP_FACEFX);
 DECLARE_CYCLE_STAT(TEXT("Update Transforms"), STAT_FaceFXUpdateTransforms, STATGROUP_FACEFX);
 DECLARE_CYCLE_STAT(TEXT("Load Assets"), STAT_FaceFXLoad, STATGROUP_FACEFX);
 DECLARE_CYCLE_STAT(TEXT("Play"), STAT_FaceFXPlay, STATGROUP_FACEFX);
-DECLARE_CYCLE_STAT(TEXT("Broadcast Events"), STAT_FaceFXEvents, STATGROUP_FACEFX);
+DECLARE_CYCLE_STAT(TEXT("Broadcast Audio Events"), STAT_FaceFXAudioEvents, STATGROUP_FACEFX);
+DECLARE_CYCLE_STAT(TEXT("Broadcast Anim Events"), STAT_FaceFXAnimEvents, STATGROUP_FACEFX);
 DECLARE_CYCLE_STAT(TEXT("Process Morph Targets"), STAT_FaceFXProcessMorphTargets, STATGROUP_FACEFX);
 DECLARE_CYCLE_STAT(TEXT("Process Material Parameters"), STAT_FaceFXProcessMaterialParameters, STATGROUP_FACEFX);
 
 namespace
 {
+#if !FFX_HAS_EVENTS
+	typedef unsigned int FFX_BONE_SET_FLAGS;
+	typedef int FFX_CHANNEL_FLAGS;
+#endif //FFX_HAS_EVENTS
+
 	EFaceFXBlendMode GetBlendMode(const UFaceFXActor* Dataset)
 	{
 		check(Dataset);
@@ -53,15 +59,20 @@ namespace
 		return BlendMode;
 	}
 
-	unsigned int GetBoneSetCreationFlags(EFaceFXBlendMode BlendMode, bool IsCompensateForForceFrontXAxis)
+	FFX_BONE_SET_FLAGS GetBoneSetCreationFlags(EFaceFXBlendMode BlendMode, bool IsCompensateForForceFrontXAxis)
 	{
+#if FFX_HAS_EVENTS
+		unsigned int BoneSetCreationFlags = BlendMode == EFaceFXBlendMode::Additive ? FFX_BONE_SET_FLAG_OFFSET_XFORMS : FFX_BONE_SET_FLAG_FULL_XFORMS;
+#else //FFX_HAS_EVENTS
 		unsigned int BoneSetCreationFlags = BlendMode == EFaceFXBlendMode::Additive ? FFX_USE_OFFSET_XFORMS : FFX_USE_FULL_XFORMS;
+#endif //FFX_HAS_EVENTS
+
 		if (IsCompensateForForceFrontXAxis)
 		{
 			BoneSetCreationFlags |= 0x80000000;
 		}
 
-		return BoneSetCreationFlags;
+		return (FFX_BONE_SET_FLAGS)BoneSetCreationFlags;
 	}
 }
 
@@ -82,6 +93,9 @@ UFaceFXCharacter::UFaceFXCharacter(const class FObjectInitializer& PCIP) : Super
 	bCompensatedForForceFrontXAxis(false),
 	bDisabledMorphTargets(false),
 	bDisabledMaterialParameters(false)
+#if FFX_HAS_EVENTS
+	,bIgnoreFaceFxEvents(false)
+#endif //FFX_HAS_EVENTS
 #if WITH_EDITOR
 	,LastFrameNumber(0)
 #endif
@@ -110,7 +124,7 @@ void UFaceFXCharacter::BeginDestroy()
 #endif
 }
 
-bool UFaceFXCharacter::TickUntil(float Duration, bool& OutAudioStarted)
+bool UFaceFXCharacter::TickUntil(float Duration, bool& OutAudioStarted, bool IgnoreFaceFxEvents)
 {
 	if(!bCanPlay || Duration < 0.F)
 	{
@@ -120,24 +134,31 @@ bool UFaceFXCharacter::TickUntil(float Duration, bool& OutAudioStarted)
 	CurrentTime = Duration;
 	CurrentAnimProgress = 0.F;
 
-	/** The steps to perform */
+	//The steps to perform
 	static const float TickSteps = 0.1F;
+
+	//apply ignore flags
+#if FFX_HAS_EVENTS
+	const bool IgnoreFaceFxEventsPrev = bIgnoreFaceFxEvents;
+	bIgnoreFaceFxEvents = IgnoreFaceFxEvents;
+#endif //FFX_HAS_EVENTS
 
 	const bool bProcessZeroSuccess = FaceFX::Check(ffx_process_frame(ActorHandle, FrameState, 0.F));
 	const bool bIsAudioStartedAtZero = IsAudioStarted();
+	const bool bResult = bProcessZeroSuccess && FaceFX::Check(ffx_process_frame(ActorHandle, FrameState, CurrentTime));
 
-	if (!bProcessZeroSuccess || !FaceFX::Check(ffx_process_frame(ActorHandle, FrameState, CurrentTime)))
+#if FFX_HAS_EVENTS
+	bIgnoreFaceFxEvents = IgnoreFaceFxEventsPrev;
+#endif //FFX_HAS_EVENTS
+
+	if (!bResult)
 	{
 		//update failed
 		UE_LOG(LogFaceFX, Error, TEXT("UFaceFXCharacter::TickUntil. FaceFX call <ffx_process_frame> failed. %s. Asset: %s"), *FaceFX::GetFaceFXError(), *GetNameSafe(FaceFXActor));
 		return false;
 	}
 
-	if(bIsAudioStartedAtZero || IsAudioStarted())
-	{
-		OutAudioStarted = true;
-	}
-
+	OutAudioStarted = bIsAudioStartedAtZero || IsAudioStarted();
 	CurrentAnimProgress = CurrentTime;
 	bIsDirty = true;
 
@@ -199,7 +220,7 @@ void UFaceFXCharacter::Tick(float DeltaTime)
 
 	if(IsAudioStarted())
 	{
-		SCOPE_CYCLE_COUNTER(STAT_FaceFXEvents);
+		SCOPE_CYCLE_COUNTER(STAT_FaceFXAudioEvents);
 		UActorComponent* AudioCompStartedOn = nullptr;
 		const bool AudioStarted = AudioPlayer->Play(&AudioCompStartedOn);
 
@@ -425,7 +446,7 @@ bool UFaceFXCharacter::Play(const UFaceFXAnim* Animation, bool Loop)
 	EnforceZeroTick();
 
 	{
-		SCOPE_CYCLE_COUNTER(STAT_FaceFXEvents);
+		SCOPE_CYCLE_COUNTER(STAT_FaceFXAudioEvents);
 		OnPlaybackStarted.Broadcast(this, GetCurrentAnimationId());
 	}
 
@@ -481,7 +502,7 @@ bool UFaceFXCharacter::Pause(bool fadeOut)
 	AudioPlayer->Pause(fadeOut);
 
 	{
-		SCOPE_CYCLE_COUNTER(STAT_FaceFXEvents);
+		SCOPE_CYCLE_COUNTER(STAT_FaceFXAudioEvents);
 		OnPlaybackPaused.Broadcast(this, GetCurrentAnimationId());
 	}
 
@@ -523,7 +544,7 @@ bool UFaceFXCharacter::Stop(bool enforceStop)
 
 	if(WasPlayingOrPaused)
 	{
-		SCOPE_CYCLE_COUNTER(STAT_FaceFXEvents);
+		SCOPE_CYCLE_COUNTER(STAT_FaceFXAudioEvents);
 		OnPlaybackStopped.Broadcast(this, StoppedAnimId);
 	}
 
@@ -578,7 +599,7 @@ bool UFaceFXCharacter::JumpTo(float Position)
 		Position = FMath::Fmod(Position, CurrentAnimDuration);
 	}
 
-	bool IsAudioStarted = false;
+	bool IsAudioStarted;
 	if(TickUntil(Position, IsAudioStarted) && IsAudioStarted)
 	{
 		const float AudioPosition = Position + CurrentAnimStart;
@@ -639,6 +660,22 @@ bool UFaceFXCharacter::IsPlayingOrPaused(const UFaceFXAnim* Animation) const
 	return Animation && IsPlayingOrPaused(Animation->GetId());
 }
 
+#if FFX_HAS_EVENTS
+void UFaceFXCharacter::OnFaceFxEvent(ffx_event_context_t* Context, const char* Payload)
+{
+	UE_LOG(LogFaceFX, Verbose, TEXT("UFaceFXCharacter::OnFaceFxEventReceived. FaceFX event received: %s."), ANSI_TO_TCHAR(Payload));
+
+	if (UFaceFXCharacter* Character = static_cast<UFaceFXCharacter*>(Context->user_data))
+	{
+		if (!Character->bIgnoreFaceFxEvents && Context->actor == Character->ActorHandle && Context->anim == Character->CurrentAnimHandle)
+		{
+			SCOPE_CYCLE_COUNTER(STAT_FaceFXAnimEvents);
+			Character->OnAnimationEvent.Broadcast(Character, Character->GetCurrentAnimationId(), Context->event_time, Payload);
+		}
+	}
+}
+#endif //FFX_HAS_EVENTS
+
 bool UFaceFXCharacter::Load(const UFaceFXActor* Dataset, bool IsCompensateForForceFrontXAxis, bool IsDisabledMorphTargets, bool IsDisableMaterialParameters)
 {
 	SCOPE_CYCLE_COUNTER(STAT_FaceFXLoad);
@@ -664,29 +701,39 @@ bool UFaceFXCharacter::Load(const UFaceFXActor* Dataset, bool IsCompensateForFor
 
 	ffx_context_t Context = FFaceFXContext::CreateContext();
 
-    //only create the bone set handle if there is bone set data
-    if(ActorData.BonesRawData.Num() > 0)
-    {
-		const unsigned int BoneSetCreationFlags = ::GetBoneSetCreationFlags(BlendMode, IsCompensateForForceFrontXAxis);
+	//only create the bone set handle if there is bone set data
+	if(ActorData.BonesRawData.Num() > 0)
+	{
+		const FFX_BONE_SET_FLAGS BoneSetCreationFlags = ::GetBoneSetCreationFlags(BlendMode, IsCompensateForForceFrontXAxis);
 
-	    if (!FaceFX::Check(ffx_create_bone_set_handle((char*)(&ActorData.BonesRawData[0]), ActorData.BonesRawData.Num(), FFX_RUN_INTEGRITY_CHECK, BoneSetCreationFlags, &BoneSetHandle, &Context)))
-	    {
-		    UE_LOG(LogFaceFX, Error, TEXT("UFaceFXCharacter::Load. Unable to create FaceFX bone handle. %s. Asset: %s"), *FaceFX::GetFaceFXError(), *GetNameSafe(FaceFXActor));
-		    Reset();
-		    return false;
-	    }
-    }
+		if (!FaceFX::Check(ffx_create_bone_set_handle((char*)(&ActorData.BonesRawData[0]), ActorData.BonesRawData.Num(), FFX_RUN_INTEGRITY_CHECK, BoneSetCreationFlags, &BoneSetHandle, &Context)))
+		{
+			UE_LOG(LogFaceFX, Error, TEXT("UFaceFXCharacter::Load. Unable to create FaceFX bone handle. %s. Asset: %s"), *FaceFX::GetFaceFXError(), *GetNameSafe(FaceFXActor));
+			Reset();
+			return false;
+		}
+	}
 
-    //make sure there is actor data
-    if(ActorData.ActorRawData.Num() == 0)
-    {
-        UE_LOG(LogFaceFX, Error, TEXT("UFaceFXCharacter::Load. No FaceFX actor data present. Asset: %s"), *GetNameSafe(FaceFXActor));
-        Reset();
-        return false;
-    }
+	//make sure there is actor data
+	if(ActorData.ActorRawData.Num() == 0)
+	{
+		UE_LOG(LogFaceFX, Error, TEXT("UFaceFXCharacter::Load. No FaceFX actor data present. Asset: %s"), *GetNameSafe(FaceFXActor));
+		Reset();
+		return false;
+	}
 
-	static size_t channel_count  = FACEFX_CHANNELS;
-	if (!FaceFX::Check(ffx_create_actor_handle((char*)(&ActorData.ActorRawData[0]), ActorData.ActorRawData.Num(), FFX_RUN_INTEGRITY_CHECK, channel_count, &ActorHandle, &Context)))
+	constexpr size_t ChannelCount = FACEFX_CHANNELS;
+
+#if FFX_HAS_EVENTS
+
+	ffx_event_handler_t EventHandler;
+	EventHandler.callback = UFaceFXCharacter::OnFaceFxEvent;
+	EventHandler.user_data = this;
+
+	if (!FaceFX::Check(ffx_create_actor_handle_with_event_handler((char*)(&ActorData.ActorRawData[0]), ActorData.ActorRawData.Num(), FFX_RUN_INTEGRITY_CHECK, ChannelCount, &ActorHandle, &EventHandler, &Context)))
+#else //FFX_HAS_EVENTS
+	if (!FaceFX::Check(ffx_create_actor_handle((char*)(&ActorData.ActorRawData[0]), ActorData.ActorRawData.Num(), FFX_RUN_INTEGRITY_CHECK, ChannelCount, &ActorHandle, &Context)))
+#endif //FFX_HAS_EVENTS
 	{
 		UE_LOG(LogFaceFX, Error, TEXT("UFaceFXCharacter::Load. Unable to create FaceFX actor handle. %s. Asset: %s"), *FaceFX::GetFaceFXError(), *GetNameSafe(FaceFXActor));
 		Reset();
@@ -700,31 +747,31 @@ bool UFaceFXCharacter::Load(const UFaceFXActor* Dataset, bool IsCompensateForFor
 		return false;
 	}
 
-    if(BoneSetHandle)
-    {
-	    size_t XFormCount = 0;
-	    if (!FaceFX::Check(ffx_get_bone_set_bone_count(BoneSetHandle, &XFormCount)))
-	    {
-		    UE_LOG(LogFaceFX, Error, TEXT("UFaceFXCharacter::Load. Unable to receive FaceFX bone count. %s. Asset: %s"), *FaceFX::GetFaceFXError(), *GetNameSafe(FaceFXActor));
-		    Reset();
-		    return false;
-	    }
+	if(BoneSetHandle)
+	{
+		size_t XFormCount = 0;
+		if (!FaceFX::Check(ffx_get_bone_set_bone_count(BoneSetHandle, &XFormCount)))
+		{
+			UE_LOG(LogFaceFX, Error, TEXT("UFaceFXCharacter::Load. Unable to receive FaceFX bone count. %s. Asset: %s"), *FaceFX::GetFaceFXError(), *GetNameSafe(FaceFXActor));
+			Reset();
+			return false;
+		}
 
 
-	    if(XFormCount > 0)
-	    {
-		    //prepare buffer
-		    XForms.AddUninitialized(XFormCount);
+		if(XFormCount > 0)
+		{
+			//prepare buffer
+			XForms.AddUninitialized(XFormCount);
 
-		    //retrieve bone names
-		    BoneIds.AddUninitialized(XFormCount);
+			//retrieve bone names
+			BoneIds.AddUninitialized(XFormCount);
 
-		    if(!FaceFX::Check(ffx_get_bone_set_bone_ids(BoneSetHandle, reinterpret_cast<uint64_t*>(BoneIds.GetData()), XFormCount)))
-		    {
-			    UE_LOG(LogFaceFX, Error, TEXT("UFaceFXCharacter::Load. Unable to receive FaceFX bone names. %s. Asset: %s"), *FaceFX::GetFaceFXError(), *GetNameSafe(FaceFXActor));
-			    Reset();
-			    return false;
-		    }
+			if(!FaceFX::Check(ffx_get_bone_set_bone_ids(BoneSetHandle, reinterpret_cast<uint64_t*>(BoneIds.GetData()), XFormCount)))
+			{
+				UE_LOG(LogFaceFX, Error, TEXT("UFaceFXCharacter::Load. Unable to receive FaceFX bone names. %s. Asset: %s"), *FaceFX::GetFaceFXError(), *GetNameSafe(FaceFXActor));
+				Reset();
+				return false;
+			}
 
 			//prepare transform buffer
 			BoneTransforms.AddZeroed(XFormCount);
@@ -741,8 +788,8 @@ bool UFaceFXCharacter::Load(const UFaceFXActor* Dataset, bool IsCompensateForFor
 					UE_LOG(LogFaceFX, Warning, TEXT("UFaceFXCharacter::Load. Unknown bone id. %i. Asset: %s"), BoneIdHash, *GetNameSafe(FaceFXActor));
 				}
 			}
-	    }
-    }
+		}
+	}
 
 	bCompensatedForForceFrontXAxis = IsCompensateForForceFrontXAxis;
 	bDisabledMorphTargets = IsDisabledMorphTargets;
@@ -1056,7 +1103,7 @@ void UFaceFXCharacter::SetAudioComponent(UActorComponent* Component)
 
 bool UFaceFXCharacter::IsAudioStarted()
 {
-	int ChannelFlags[FACEFX_CHANNELS];
+	FFX_CHANNEL_FLAGS ChannelFlags[FACEFX_CHANNELS];
 	if(FaceFX::Check(ffx_read_frame_channel_flags(FrameState, ChannelFlags, FACEFX_CHANNELS)))
 	{
 		return (ChannelFlags[0] & FFX_START_AUDIO) != 0;
@@ -1114,34 +1161,34 @@ void UFaceFXCharacter::UpdateTransforms()
 	SCOPE_CYCLE_COUNTER(STAT_FaceFXUpdateTransforms);
 
 	const int32 XFormsNum = XForms.Num();
-    if(BoneSetHandle && XFormsNum > 0)
-    {
-	    if(!FaceFX::Check(ffx_calc_frame_bone_xforms(BoneSetHandle, FrameState, &XForms[0], XFormsNum)))
-	    {
-		    UE_LOG(LogFaceFX, Error, TEXT("UFaceFXCharacter::UpdateTransforms. Calculating bone transforms failed. %s. Asset: %s"), *FaceFX::GetFaceFXError(), *GetNameSafe(FaceFXActor));
-		    return;
-	    }
+	if(BoneSetHandle && XFormsNum > 0)
+	{
+		if(!FaceFX::Check(ffx_calc_frame_bone_xforms(BoneSetHandle, FrameState, &XForms[0], XFormsNum)))
+		{
+			UE_LOG(LogFaceFX, Error, TEXT("UFaceFXCharacter::UpdateTransforms. Calculating bone transforms failed. %s. Asset: %s"), *FaceFX::GetFaceFXError(), *GetNameSafe(FaceFXActor));
+			return;
+		}
 
-	    //fill transform buffer
-	    for(int32 i=0; i<XFormsNum; ++i)
-	    {
-		    const ffx_bone_xform_t& XForm = XForms[i];
+		//fill transform buffer
+		for(int32 i=0; i<XFormsNum; ++i)
+		{
+			const ffx_bone_xform_t& XForm = XForms[i];
 
-		    //the coordinate system of bones is just like the old FaceFX in UE3: native for the animation package you used to create the actor, with the w component of the quaternion negated
-		    //All transforms are in parent space.
-		    //We also need to bring form FaceFX to UE space by reverting rotation.z and translation.y
+			//the coordinate system of bones is just like the old FaceFX in UE3: native for the animation package you used to create the actor, with the w component of the quaternion negated
+			//All transforms are in parent space.
+			//We also need to bring form FaceFX to UE space by reverting rotation.z and translation.y
 
-		    BoneTransforms[i].SetComponents(
-			    //w, x, y, z quaternion rotation
-			    FQuat(XForm.rot[1], -XForm.rot[2], XForm.rot[3], XForm.rot[0]),
-			    //x, y, z position
-			    FVector(XForm.pos[0], -XForm.pos[1], XForm.pos[2]),
-			    //x, y, z scale
-			    FVector(XForm.scl[0], XForm.scl[1], XForm.scl[2]));
-	    }
+			BoneTransforms[i].SetComponents(
+				//w, x, y, z quaternion rotation
+				FQuat(XForm.rot[1], -XForm.rot[2], XForm.rot[3], XForm.rot[0]),
+				//x, y, z position
+				FVector(XForm.pos[0], -XForm.pos[1], XForm.pos[2]),
+				//x, y, z scale
+				FVector(XForm.scl[0], XForm.scl[1], XForm.scl[2]));
+		}
 
-	    bIsDirty = false;
-    }
+		bIsDirty = false;
+	}
 }
 
 

--- a/Source/FaceFX/Public/FaceFXConfig.h
+++ b/Source/FaceFX/Public/FaceFXConfig.h
@@ -87,6 +87,8 @@
     "FaceFX Sequencer support requires Unreal Engine 4.12 or higher. Please update your engine or use a previous version of the plugin.";
 #endif
 
+// Support for event notifiers coming from within the FaceFX runtime
+#define FFX_HAS_EVENTS (FFX_VERSION >= FFX_MAKE_VERSION(1,7,0))
 
 /** Blend mode for FaceFX runtime */
 UENUM()


### PR DESCRIPTION
- Support for events which are set within FaceFX studio and triggered by the FaceFX runtime during animation playback
- Toggable via IsIgnoreFaceFxEvents flag on the Blueprint setup node
- If enabled events are dispatched to the animation system and trigger anim/skeleton notifiers. They're also dispatched to user C++ callbacks
- Requires FaceFX runtime 1.7.0+